### PR TITLE
The Helm Way. Better Compose and Quadlet logistics

### DIFF
--- a/proposals/the-helm-way/PATCH_desired-state-quadlet.diff
+++ b/proposals/the-helm-way/PATCH_desired-state-quadlet.diff
@@ -1,0 +1,108 @@
+# PATCH: desired-state.linkml.yaml -- Add QuadletDeploymentProfile and QuadletComponent
+#
+# Schema file:
+#   src/specification/margo-management-interface/desired-state.linkml.yaml
+#
+# Purpose:
+#   Close R3 gap identified by margo-tech-reviewer in REVIEW_tech-reviewer.md.
+#   Without these additions, WFMs cannot generate schema-valid
+#   ApplicationDeployment desired-state documents for Quadlet workloads.
+#   The type slot accepts the string "quadlet" (no pattern constraint exists
+#   in the desired-state schema) but there is no QuadletDeploymentProfile or
+#   QuadletComponent class to validate against, leaving Quadlet desired-state
+#   documents effectively untyped.
+#
+# How to apply:
+#   This unified diff is NOT committed directly to the submodule. To apply:
+#
+#       cd documentation/spec_analysis/specification
+#       patch -p1 < ../proposals/PATCH_desired-state-quadlet.diff
+#
+#   After applying, run the validation toolchain:
+#
+#       bash doc-generation/check-examples.bash
+#
+# Structural rationale:
+#   In desired-state.linkml.yaml the Component class uses
+#   "range: Property" (a name/value pair list, lines 151-158), NOT
+#   "range: ComponentProperties" as in application-description.linkml.yaml.
+#   This reflects the different role of the two schemas: the desired-state
+#   document carries runtime parameter injection (name/value pairs injected
+#   by the WFM) whereas the ApplicationDescription carries OCI package
+#   registry coordinates (ComponentProperties with repository/revision).
+#
+#   QuadletComponent therefore inherits from the same Component base class
+#   as HelmComponent and ComposeComponent, using the name/value Property
+#   model. No new Property subclass is needed.
+#
+#   The type slot description is updated to document the three accepted
+#   values. No pattern constraint is added here (consistent with the
+#   existing schema which omits a pattern on the desired-state type slot).
+#   Adding a pattern would be a separate, follow-up schema hardening change.
+#
+# Dependency:
+#   This patch is a companion to WG-PROPOSAL-01. It MUST be applied
+#   after (or simultaneously with) the application-description.linkml.yaml
+#   changes from that proposal.
+
+--- a/src/specification/margo-management-interface/desired-state.linkml.yaml
++++ b/src/specification/margo-management-interface/desired-state.linkml.yaml
+@@ -130,6 +130,19 @@ classes:
+   ComposeDeploymentProfile:
+     is_a: DeploymentProfile
+     rank: 40
+     slot_usage:
+       type:
+         equals_string: "compose"
+         rank: 10
+       components:
+         range: ComposeComponent
+         rank: 20
+
++  QuadletDeploymentProfile:
++    is_a: DeploymentProfile
++    description: >-
++      Deployment profile for Quadlet-based workloads targeting devices running
++      Podman 5.0 or later with systemd integration. Components are referenced
++      via repository (an oci:// URI) and revision (an OCI tag) consistent with
++      the Helm and Compose OCI publishing model mandated by WG-PROPOSAL-01.
++    rank: 40
++    slot_usage:
++      type:
++        equals_string: "quadlet"
++        rank: 10
++      components:
++        range: QuadletComponent
++        rank: 20
++
+   Component:
+     description: A class representing a component of a deployment profile.
+     rank: 50
+@@ -160,6 +173,12 @@ classes:
+   ComposeComponent:
+     is_a: Component
+     rank: 50
+
++  QuadletComponent:
++    is_a: Component
++    rank: 50
++    description: >-
++      A component packaged as a Quadlet Archive for deployment on devices using
++      Podman with systemd integration. Properties follow the same name/value
++      pair model as HelmComponent and ComposeComponent in this schema.
++
+   Property:
+     rank: 80
+     attributes:
+@@ -213,7 +232,11 @@ slots:
+   type:
+-    description: The type of deployment profile (e.g., helm.v3, compose).
++    description: >-
++      The type of deployment profile. Allowed values are: helm.v3 (Kubernetes/Helm
++      chart deployment), compose (Compose file deployment via Podman or Docker
++      Compose), and quadlet (Podman systemd Quadlet unit file deployment). The
++      value MUST match the type field in the corresponding ApplicationDescription
++      deploymentProfile element.
+     range: string
+     required: true
+     rank: 10

--- a/proposals/the-helm-way/README.md
+++ b/proposals/the-helm-way/README.md
@@ -1,0 +1,48 @@
+# Margo WG -- Specification Enhancement Proposals
+
+| Field | Value |
+|-------|-------|
+| **Package date** | 2026-05-07 |
+| **Prepared by** | Andrii Melashchenko (Belden Inc.) |
+| **Status** | Ready for public review |
+| **Applies to** | Margo specification pre-draft |
+
+---
+
+## Documents
+
+| File | Title | Type | Status |
+|------|-------|------|--------|
+| `WG-PROPOSAL-00_the-helm-way.md` | The Helm Way -- Canonical OCI Component Publishing Pattern | Informational | Rev 1 |
+| `WG-PROPOSAL-01_compose-oci-and-structure.md` | Compose OCI Registry Publishing and Archive Structure | Cat 2 normative | Rev 1 |
+| `WG-PROPOSAL-02_quadlet-component-type.md` | Quadlet Component Type | Cat 2 normative | Rev 1 |
+| `WG-PROPOSAL-03_apiversion-evolution-strategy.md` | API Version Evolution Strategy | Cat 2 normative | Rev 2 |
+| `PATCH_desired-state-quadlet.diff` | Desired-state schema patch for Quadlet | Companion artifact | Ready to apply |
+
+---
+
+## Summary of Changes
+
+**P-00 -- The Helm Way** (informational, no spec diffs): Names the five-element OCI publishing pattern already implemented by Helm -- Storage, Reference, Media Types, Integrity, Parametrization. Serves as the reference all other proposals point to.
+
+**P-01 -- Compose OCI** (normative): Mandates OCI registry storage for Compose Archives. Introduces `compose.v1` deployment profile type, two new media types, normative archive structure, and deprecates `packageLocation`.
+
+**P-02 -- Quadlet** (normative): Introduces Quadlet as a third component type (`quadlet.v1`) for native systemd container management on OT edge devices. Defines schema classes, media types, and archive structure.
+
+**P-03 -- API Version Evolution** (normative): Adds `pattern` constraints to `apiVersion` in both `ApplicationDescription` and `DesiredState` schemas. Introduces a normative version catalogue, lifecycle states (Alpha → Beta → Stable → Deprecated → Removed), WFM rejection/warning behaviour, and compatibility rules.
+
+---
+
+## Application Order
+
+```
+P-00 (informational)  -->  P-01 (Compose)  -->  P-02 (Quadlet)
+
+P-03 (API Version) -- independent, may be applied at any point
+```
+
+P-01 must be applied before P-02. P-03 is independent of P-01 and P-02.
+
+---
+
+*Subject to the Open Web Foundation Contributor License Agreement governing the Margo specification.*

--- a/proposals/the-helm-way/WG-PROPOSAL-00_the-helm-way.md
+++ b/proposals/the-helm-way/WG-PROPOSAL-00_the-helm-way.md
@@ -1,0 +1,111 @@
+# WG-PROPOSAL-00: The Helm Way -- Canonical OCI Component Publishing Pattern
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-04 |
+| Category | Informational |
+| Issues | None (pattern definition) |
+| Affects | None (no spec diffs) |
+| Status | Rev 1 -- ready for public review |
+
+## Purpose
+
+The Margo specification already provides a mature, OCI-native publishing workflow for Helm-based components. This document names that workflow "The Helm Way" and distills it into five reusable elements so that future component types (Compose, Quadlet, or any type added later) can reference a single, well-defined pattern rather than repeating the same requirements in every proposal. This document is informational only -- it introduces no normative changes and does not modify any specification file.
+
+> **Note on signing**: Artifact signing (provenance, supply chain attestation) is out of scope for this proposal package. The OCI content-addressable digest already provides transport integrity. Signing policy belongs in a dedicated Margo security specification and is deferred to a future proposal.
+
+## The Pattern
+
+"The Helm Way" is a five-element pattern for storing, referencing, identifying, verifying, and parameterizing component artifacts within the Margo ecosystem. Any component type that follows all five elements is said to conform to The Helm Way.
+
+### 1. Storage
+
+The component artifact MUST be stored in an OCI-compliant [Component Registry](../../specification/applications/application-registry.md). The registry MUST support OCI artifacts as defined in the OCI Image Specification v1.1.0. The publishing tool (e.g., `helm push`, `oras push`) MUST produce a valid OCI image manifest.
+
+### 2. Reference
+
+The [ApplicationDescription](../../specification/applications/application-description.md#componentproperties-attributes) MUST identify the component using two fields:
+
+- `repository` -- an `oci://` URI pointing to the registry and repository path (e.g., `oci://registry.example.com/org/component-name`)
+- `revision` -- an OCI tag identifying the component version (e.g., `1.0.0`, `2.3.1`) (SemVer 2.0 version without leading `v`)
+
+Together, `repository` + `revision` provide a deterministic, human-readable coordinate for the artifact. No other location field (e.g., a plain-HTTPS URL) is required.
+
+### 3. Media Types
+
+The OCI image manifest MUST declare a component-type-specific `artifactType` so that registries and tooling can distinguish Margo component artifacts from other OCI content. The layer blob containing the component payload MUST declare a component-type-specific `mediaType` so that consumers can verify they are processing the correct binary format.
+
+Media type strings MUST follow the `application/vnd.org.margo.<hierarchy>` naming convention (reversed domain `org.margo` for the Margo project domain `margo.org`) and MUST be registered in the Margo-Specific Media Types table in [application-registry.md](../../specification/applications/application-registry.md).
+
+### 4. Integrity
+
+Integrity verification is provided by the OCI content-addressable digest as mandated by the [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md), which the Margo Application Registry already requires. Implementations MUST verify the digest after pulling and before extracting or processing the artifact. No separate `digest` or hash field is needed in the ApplicationDescription.
+
+### 5. Parametrization
+
+Each component type SHOULD define how ApplicationDescription `Parameter` values are delivered
+to the running component at deployment time. The delivery mechanism is component-type-specific
+and declared in the component type proposal.
+
+Each new component type proposal SHOULD specify:
+- The **parameter artifact** -- the file or mechanism by which resolved parameter values reach
+  the component (e.g., a values override file, an env file, a configuration file).
+- The **`pointer` syntax** -- the convention used in `Target.pointer` to identify the
+  parameter's location within the artifact (e.g., dot-notation for a YAML tree, a named
+  environment variable).
+
+A single `Parameter` MAY declare targets with different pointer syntaxes, allowing the same
+logical value to be delivered to components of different types simultaneously.
+
+## Helm as the Reference Implementation
+
+Helm already satisfies all five elements of The Helm Way:
+
+- **Storage**: `helm push` stores Helm charts in any OCI-compliant registry.
+- **Reference**: The ApplicationDescription uses `repository: oci://...` and `revision: <tag>` to identify the chart.
+- **Media types**: The OCI manifest uses `artifactType: application/vnd.cncf.helm.config.v1+json` and the layer blob uses `mediaType: application/vnd.cncf.helm.chart.content.layer.v1.tar+gzip`, both community-standard CNCF media types.
+- **Integrity**: The OCI content-addressable digest on the chart layer blob provides integrity verification per the OCI Distribution Specification v1.1.0.
+- **Parametrization**: `helm install` accepts a `values.yaml` override file (via `-f values.yaml`)
+  or individual `--set` flags. The ApplicationDescription `Target.pointer` uses dot-notation to
+  identify the target key within the values tree (e.g., `config.database.host`).
+
+Helm's compliance with this pattern is inherent -- no specification changes are required for Helm components. The Helm Way simply names what Helm already does.
+
+## Pattern Compliance Table
+
+Any new component type proposal MUST demonstrate compliance with all five elements. The table below shows the reference implementation (Helm) alongside the two component types introduced by WG-PROPOSAL-01 and WG-PROPOSAL-02.
+
+| Element | Requirement | Helm (reference) | Compose (P-01) | Quadlet (P-02) |
+|---------|------------|-----------------|----------------|----------------|
+| Registry | OCI-compliant, MUST | `helm push` | `oras push` | `oras push` |
+| `type` value | versioned string, MUST | `helm.v3` | `compose.v1` | `quadlet.v1` |
+| `repository` field | `oci://` URI, MUST | `oci://registry/org/chart` | `oci://registry/org/app` | `oci://registry/org/app` |
+| `revision` field | OCI tag, MUST | `1.0.0` | `1.0.0` | `1.0.0` |
+| `artifactType` | Margo-registered, MUST | `application/vnd.cncf.helm.config.v1+json` | `application/vnd.org.margo.component.compose.v1+json` | `application/vnd.org.margo.component.quadlet.v1+json` |
+| Layer `mediaType` | Margo-registered, MUST | `application/vnd.cncf.helm.chart.content.layer.v1.tar+gzip` | `application/vnd.org.margo.component.compose.v1.tar.gzip` | `application/vnd.org.margo.component.quadlet.v1.tar.gzip` |
+| Integrity | OCI digest per OCI Distribution Spec v1.1.0 | Verified by registry and Helm CLI | Verified by registry and WFM | Verified by registry and WFM |
+| Parametrization | parameter artifact SHOULD be defined | `values.yaml` override | `margo-params.env` file | `margo-params.env` file (shared with Compose) |
+
+## Relationship to Other Proposals
+
+This document is informational only. It does not modify any normative specification file.
+
+The normative changes that apply The Helm Way to Compose components are defined in **WG-PROPOSAL-01** (`WG-PROPOSAL-01_compose-oci-and-structure.md`). The normative changes that apply The Helm Way to Quadlet components are defined in **WG-PROPOSAL-02** (`WG-PROPOSAL-02_quadlet-component-type.md`).
+
+Component type proposals that define a parameter artifact and pointer syntax SHOULD reference the Parametrization element and fill in the corresponding row of the Pattern Compliance Table.
+
+Future component type proposals SHOULD reference this document and fill in the Pattern Compliance Table to demonstrate conformance with The Helm Way.
+
+---
+
+## References
+
+- [OCI Image Specification v1.1.0](https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md)
+- [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md)
+- [Helm OCI Support](https://helm.sh/docs/topics/registries/)
+- [ORAS (OCI Registry as Storage)](https://oras.land/)
+- [RFC 6838 -- Media Type Specifications and Registration Procedures](https://www.rfc-editor.org/rfc/rfc6838)
+
+---
+
+*This document is part of the Margo WG Compose/Quadlet OCI Publishing proposal package. Prepared by Andrii Melashchenko, 2026-05-04. Subject to the Open Web Foundation Contributor License Agreement governing the Margo specification.*

--- a/proposals/the-helm-way/WG-PROPOSAL-01_compose-oci-and-structure.md
+++ b/proposals/the-helm-way/WG-PROPOSAL-01_compose-oci-and-structure.md
@@ -1,0 +1,681 @@
+# WG-PROPOSAL-01: Compose OCI Registry Publishing and Archive Structure
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-04 |
+| Category | Cat 2 -- normative enhancement |
+| Affects | `system-design/concepts/applications/application-package.md`, `system-design/specification/applications/application-registry.md`, `src/specification/applications/application-description.linkml.yaml` |
+| Status | Rev 1 -- ready for public review |
+
+## Motivation
+
+This proposal applies The Helm Way pattern (WG-PROPOSAL-00) to Compose components. The Helm Way establishes that all Margo component types should follow the OCI registry-based publishing model already implemented by Helm: store in an OCI registry, reference via `repository`+`revision`, declare component-type-specific media types, and verify integrity via OCI content-addressable digest. This proposal mandates OCI registry storage for Compose Archives, introduces Margo-specific OCI media types, defines the normative internal archive structure, deprecates the `packageLocation` field, and resolves the open "Investigation Needed" blocks. These changes are inseparable: what you push to the registry is defined by the archive structure, so the OCI mandate and the structure specification belong in a single document.
+
+The current specification describes the Compose Archive as "a tarball file containing the `compose.yaml` file and any additional artifacts referenced by the Compose file." This single-sentence description is insufficient for interoperable implementations. Five specific gaps exist in the Compose packaging model: the OCI registry mandate is absent, the integrity mechanism is unspecified, an `artifactType` string inconsistency exists in the Mermaid diagram, the type discriminator uses a bare string instead of a versioned value, and the archive structure is not normatively defined.
+
+---
+
+## Proposed Changes
+
+### Change 1: `system-design/concepts/applications/application-package.md`
+
+---
+
+#### Change 1a: Replace Compose bullet with OCI-mandated language
+
+This change rewrites the Compose component bullet to mandate OCI registry storage following The Helm Way pattern (WG-PROPOSAL-00). The Helm bullet is also tightened with explicit OCI language. The Quadlet bullet is introduced separately in WG-PROPOSAL-02.
+
+**Before** (lines 46-54)
+
+```markdown
+ The components are being deployed as workloads on the edge devices:
+
+- To target devices, which deploy workloads using Kubernetes, components need to be defined as Helm charts using [Helm (version 3)](https://helm.sh/docs/topics/charts/).
+- To target devices, which deploy workloads using [Compose](https://www.compose-spec.io/), components need to be packaged as [Compose Archives](../../personas-and-definitions/technical-lexicon.md#compose-archive), i.e., a tarball file containing the `compose.yaml` file and any additional artifacts referenced by the Compose file (e.g., configuration files, environment variable files, etc.). Margo recommends to digitally sign this package and to specify the location of the public key in the `ApplicationDescription` (see `keyLocation` [here](../../specification/applications/application-description.md#componentproperties-attributes)). When digitally signing the package PGP encryption MUST be used.
+
+If either one cannot be implemented it MAY be omitted but Margo RECOMMENDS defining [deployment profiles](../../specification/applications/application-description.md#deploymentprofile-attributes) as both Helm chart **AND** Compose components to strengthen interoperability and applicability.
+
+> **Note**
+> A device running the application will only install the application using either the Compose Archives or the Helm Charts, but not both.
+```
+
+**After**
+
+```markdown
+ The components are being deployed as workloads on the edge devices:
+
+- To target devices which deploy workloads using Kubernetes, components MUST be defined as Helm charts using [Helm (version 3)](https://helm.sh/docs/topics/charts/). Helm charts MUST be stored in an OCI-compliant [Component Registry](../../personas-and-definitions/technical-lexicon.md#component-registry) and referenced via `repository` (an `oci://` URI) and `revision` (an OCI tag) in the [ApplicationDescription](../../specification/applications/application-description.md#componentproperties-attributes).
+- To target devices which deploy workloads using [Compose](https://www.compose-spec.io/), the following requirements apply:
+  1. Components MUST be packaged as [Compose Archives](../../personas-and-definitions/technical-lexicon.md#compose-archive) (see [Compose Archive Structure](#compose-archive-structure) below).
+  2. Compose Archives MUST be stored in an OCI-compliant [Component Registry](../../personas-and-definitions/technical-lexicon.md#component-registry).
+  3. The Compose Archive MUST be pushed to the registry as an OCI artifact (e.g., using `oras push` or equivalent tooling) and referenced via `repository` (an `oci://` URI) and `revision` (an OCI tag) in the [ApplicationDescription](../../specification/applications/application-description.md#componentproperties-attributes).
+  4. The OCI image manifest for the artifact MUST use `application/vnd.org.margo.component.compose.v1+json` as its `artifactType`.
+  5. The layer blob containing the tarball MUST use `application/vnd.org.margo.component.compose.v1.tar.gzip` as its `mediaType`.
+  6. Integrity of the Compose Archive is provided by the OCI content-addressable digest as mandated by the [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md), which the Margo Application Registry already requires.
+
+If any one component type cannot be implemented it MAY be omitted, but Margo RECOMMENDS defining [deployment profiles](../../specification/applications/application-description.md#deploymentprofile-attributes) using multiple component types (Helm, Compose, and/or Quadlet) to strengthen interoperability and applicability across heterogeneous edge device fleets.
+
+> **Note**
+> A device running the application will only install the application using one component type (Helm Charts, Compose Archives, or Quadlet Archives), never more than one simultaneously.
+```
+
+**Diff**
+
+```diff
+  The components are being deployed as workloads on the edge devices:
+
+-- To target devices, which deploy workloads using Kubernetes, components need to be defined as Helm charts using [Helm (version 3)](https://helm.sh/docs/topics/charts/).
+-- To target devices, which deploy workloads using [Compose](https://www.compose-spec.io/), components need to be packaged as [Compose Archives](../../personas-and-definitions/technical-lexicon.md#compose-archive), i.e., a tarball file containing the `compose.yaml` file and any additional artifacts referenced by the Compose file (e.g., configuration files, environment variable files, etc.). Margo recommends to digitally sign this package and to specify the location of the public key in the `ApplicationDescription` (see `keyLocation` [here](../../specification/applications/application-description.md#componentproperties-attributes)). When digitally signing the package PGP encryption MUST be used.
++- To target devices which deploy workloads using Kubernetes, components MUST be defined as Helm charts using [Helm (version 3)](https://helm.sh/docs/topics/charts/). Helm charts MUST be stored in an OCI-compliant [Component Registry](../../personas-and-definitions/technical-lexicon.md#component-registry) and referenced via `repository` (an `oci://` URI) and `revision` (an OCI tag) in the [ApplicationDescription](../../specification/applications/application-description.md#componentproperties-attributes).
++- To target devices which deploy workloads using [Compose](https://www.compose-spec.io/), the following requirements apply:
++  1. Components MUST be packaged as [Compose Archives](../../personas-and-definitions/technical-lexicon.md#compose-archive) (see [Compose Archive Structure](#compose-archive-structure) below).
++  2. Compose Archives MUST be stored in an OCI-compliant [Component Registry](../../personas-and-definitions/technical-lexicon.md#component-registry).
++  3. The Compose Archive MUST be pushed to the registry as an OCI artifact (e.g., using `oras push` or equivalent tooling) and referenced via `repository` (an `oci://` URI) and `revision` (an OCI tag) in the [ApplicationDescription](../../specification/applications/application-description.md#componentproperties-attributes).
++  4. The OCI image manifest for the artifact MUST use `application/vnd.org.margo.component.compose.v1+json` as its `artifactType`.
++  5. The layer blob containing the tarball MUST use `application/vnd.org.margo.component.compose.v1.tar.gzip` as its `mediaType`.
++  6. Integrity of the Compose Archive is provided by the OCI content-addressable digest as mandated by the [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md), which the Margo Application Registry already requires.
+
+-If either one cannot be implemented it MAY be omitted but Margo RECOMMENDS defining [deployment profiles](../../specification/applications/application-description.md#deploymentprofile-attributes) as both Helm chart **AND** Compose components to strengthen interoperability and applicability.
++If any one component type cannot be implemented it MAY be omitted, but Margo RECOMMENDS defining [deployment profiles](../../specification/applications/application-description.md#deploymentprofile-attributes) using multiple component types (Helm, Compose, and/or Quadlet) to strengthen interoperability and applicability across heterogeneous edge device fleets.
+
+ > **Note**
+-> A device running the application will only install the application using either the Compose Archives or the Helm Charts, but not both.
++> A device running the application will only install the application using one component type (Helm Charts, Compose Archives, or Quadlet Archives), never more than one simultaneously.
+```
+
+---
+
+#### Change 1b: Resolve three "Investigation Needed" blocks
+
+**Before** (lines 57-64)
+
+```markdown
+Margo will provide more detailed discussion and specification on the following points:
+
+> **Investigation Needed**: Question: do we need to specify the location of a SHA256 hash for the Compose Archive also (similar to the PGP key) in the ApplicationDescription?
+> We will also discuss how we should handle secure container registries that require a username and password.
+>
+> **Investigation Needed**: We need to determine what impact, if any, using 3rd party helm charts has on being Margo compliant.
+>
+> **Investigation Needed**: Missing in the current specification are ways to define dependencies (e.g., application dependencies) as well as required infrastructure services such as storage, message queues/bus, reverse proxy, or authentication/authorization/accounting.
+```
+
+**After**
+
+```markdown
+> **Resolved (WG-PROPOSAL-01)**: The integrity question is resolved by mandating OCI registry storage for all component types. Integrity verification is provided by the OCI content-addressable digest as mandated by the [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md), which the Margo Application Registry already requires. No separate `digest` field is needed in the ApplicationDescription. Authentication for secure container registries SHOULD follow the mechanisms defined in the [Authentication, Authorization & Security](../../specification/applications/application-registry.md#authentication-authorization--security) section.
+
+> **Resolved (WG-PROPOSAL-01)**: Using 3rd-party Helm charts as components in an Application Package does not affect Margo compliance of the Application Package itself. Margo compliance is determined by the conformance of the ApplicationDescription and its packaging within the Application Registry. The 3rd-party chart need not be "Margo-aware"; however, the application developer is responsible for ensuring the chart functions correctly on Margo-compliant edge devices. The `pointer` field in Parameter Targets works with any Helm chart's `values.yaml` structure. Application developers SHOULD document known limitations of 3rd-party charts (e.g., charts requiring CRDs, admission webhooks, or cluster-scoped resources) in the deployment profile `description` field.
+
+> **Deferred**: Defining application dependencies and required infrastructure services (storage, message queues, reverse proxy, authentication/authorization/accounting) is deferred to a separate proposal. This topic requires coordination with the Margo Device Interface working group.
+```
+
+**Diff**
+
+```diff
+-Margo will provide more detailed discussion and specification on the following points:
+-
+-> **Investigation Needed**: Question: do we need to specify the location of a SHA256 hash for the Compose Archive also (similar to the PGP key) in the ApplicationDescription?
+-> We will also discuss how we should handle secure container registries that require a username and password.
+->
+-> **Investigation Needed**: We need to determine what impact, if any, using 3rd party helm charts has on being Margo compliant.
+->
+-> **Investigation Needed**: Missing in the current specification are ways to define dependencies (e.g., application dependencies) as well as required infrastructure services such as storage, message queues/bus, reverse proxy, or authentication/authorization/accounting.
++> **Resolved (WG-PROPOSAL-01)**: The integrity question is resolved by mandating OCI registry storage for all component types. Integrity verification is provided by the OCI content-addressable digest as mandated by the [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md), which the Margo Application Registry already requires. No separate `digest` field is needed in the ApplicationDescription. Authentication for secure container registries SHOULD follow the mechanisms defined in the [Authentication, Authorization & Security](../../specification/applications/application-registry.md#authentication-authorization--security) section.
++
++> **Resolved (WG-PROPOSAL-01)**: Using 3rd-party Helm charts as components in an Application Package does not affect Margo compliance of the Application Package itself. Margo compliance is determined by the conformance of the ApplicationDescription and its packaging within the Application Registry. The 3rd-party chart need not be "Margo-aware"; however, the application developer is responsible for ensuring the chart functions correctly on Margo-compliant edge devices. The `pointer` field in Parameter Targets works with any Helm chart's `values.yaml` structure. Application developers SHOULD document known limitations of 3rd-party charts (e.g., charts requiring CRDs, admission webhooks, or cluster-scoped resources) in the deployment profile `description` field.
++
++> **Deferred**: Defining application dependencies and required infrastructure services (storage, message queues, reverse proxy, authentication/authorization/accounting) is deferred to a separate proposal. This topic requires coordination with the Margo Device Interface working group.
+```
+
+---
+
+### Change 2: `system-design/specification/applications/application-registry.md`
+
+#### Change 2a: Add Compose media types to Margo-Specific Media Types table
+
+**Before** (lines 222-231)
+
+```markdown
+#### Margo-Specific Media Types
+
+|Media Type|Description|
+|----------|----------|
+|``application/vnd.org.margo.app.v1+json`` | MUST be used as the **artifactType** to mark the OCI image manifest as the definition of a Margo Application Package |
+|``application/vnd.org.margo.app.description.v1+yaml`` | MUST be used to mark a layer in the OCI image manifest as pointing to the Margo Application Description file |
+|``application/vnd.org.margo.app.icon.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to the icon of a Margo Application Package |
+|``application/vnd.org.margo.app.descriptionFile.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to description file of a Margo Application Package |
+|``application/vnd.org.margo.app.licenseFile.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to the license file of a Margo Application Package|
+|``application/vnd.org.margo.app.releaseNotes.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to the release notes file of a Margo Application Package|
+```
+
+**After**
+
+```markdown
+#### Margo-Specific Media Types
+
+##### Application Package Media Types
+
+|Media Type|Description|
+|----------|----------|
+|``application/vnd.org.margo.app.v1+json`` | MUST be used as the **artifactType** to mark the OCI image manifest as the definition of a Margo Application Package |
+|``application/vnd.org.margo.app.description.v1+yaml`` | MUST be used to mark a layer in the OCI image manifest as pointing to the Margo Application Description file |
+|``application/vnd.org.margo.app.icon.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to the icon of a Margo Application Package |
+|``application/vnd.org.margo.app.descriptionFile.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to description file of a Margo Application Package |
+|``application/vnd.org.margo.app.licenseFile.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to the license file of a Margo Application Package|
+|``application/vnd.org.margo.app.releaseNotes.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to the release notes file of a Margo Application Package|
+
+##### Component Registry Media Types
+
+|Media Type|Description|
+|----------|----------|
+|``application/vnd.org.margo.component.compose.v1+json``| MUST be used as the **artifactType** to mark an OCI image manifest as a Margo Compose Archive component in a Component Registry |
+|``application/vnd.org.margo.component.compose.v1.tar.gzip``| MUST be used as the **mediaType** for the layer blob containing the Compose Archive tarball (.tar.gz) |
+```
+
+**Diff**
+
+```diff
+ #### Margo-Specific Media Types
+
++##### Application Package Media Types
++
+ |Media Type|Description|
+ |----------|----------|
+ |``application/vnd.org.margo.app.v1+json`` | MUST be used as the **artifactType** to mark the OCI image manifest as the definition of a Margo Application Package |
+ |``application/vnd.org.margo.app.description.v1+yaml`` | MUST be used to mark a layer in the OCI image manifest as pointing to the Margo Application Description file |
+ |``application/vnd.org.margo.app.icon.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to the icon of a Margo Application Package |
+ |``application/vnd.org.margo.app.descriptionFile.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to description file of a Margo Application Package |
+ |``application/vnd.org.margo.app.licenseFile.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to the license file of a Margo Application Package|
+ |``application/vnd.org.margo.app.releaseNotes.v1+{file format}``| MUST be used to mark a layer in the OCI image manifest as pointing to the release notes file of a Margo Application Package|
++
++##### Component Registry Media Types
++
++|Media Type|Description|
++|----------|----------|
++|``application/vnd.org.margo.component.compose.v1+json``| MUST be used as the **artifactType** to mark an OCI image manifest as a Margo Compose Archive component in a Component Registry |
++|``application/vnd.org.margo.component.compose.v1.tar.gzip``| MUST be used as the **mediaType** for the layer blob containing the Compose Archive tarball (.tar.gz) |
+```
+
+> **Note:** Quadlet media types (`application/vnd.org.margo.component.quadlet.v1+json` and `application/vnd.org.margo.component.quadlet.v1.tar.gzip`) are introduced in WG-PROPOSAL-02 and MUST be added to this table when that proposal is applied.
+
+---
+
+### Change 3: `src/specification/applications/application-description.linkml.yaml`
+
+#### Change 3a: Deprecate `packageLocation`, update `repository`/`revision` descriptions
+
+**Before** (lines 385-412)
+
+```yaml
+  ComponentProperties:
+    description: Properties dictionary for component deployment details.
+    rank: 80
+    attributes:
+      repository:
+        description: Repository location for the component.
+        rank: 10
+        range: string
+      revision:
+        description: Revision version for the component.
+        rank: 20
+        range: string
+      wait:
+        description: If True, indicates the device waits for the component installation to complete.
+        rank: 30
+        range: boolean
+      timeout:
+        description: Time to wait for component installation to complete, formatted as "##m##s".
+        rank: 40
+        range: string
+      packageLocation:
+        description: URL indicating the Compose package's location.
+        rank: 50
+        range: string
+      keyLocation:
+        description: URL for the public key used to validate a digitally signed package.
+        rank: 60
+        range: string
+```
+
+**After**
+
+```yaml
+  ComponentProperties:
+    description: Properties dictionary for component deployment details.
+    rank: 80
+    attributes:
+      repository:
+        description: >-
+          OCI repository URI for the component (e.g., oci://registry.example.com/org/component-name).
+          MUST be used for Helm, Compose, and Quadlet components.
+        rank: 10
+        range: string
+        required: false  # Becomes required: true in Phase 2 (v1-beta1)
+      revision:
+        description: >-
+          OCI tag identifying the component version within the repository (e.g., "1.0.0", "2.3.1").
+          SemVer 2.0 version without leading `v`.
+          MUST be used for Helm, Compose, and Quadlet components.
+        rank: 20
+        range: string
+        required: false  # Becomes required: true in Phase 2 (v1-beta1)
+      wait:
+        description: If True, indicates the device waits for the component installation to complete.
+        rank: 30
+        range: boolean
+      timeout:
+        description: Time to wait for component installation to complete, formatted as "##m##s".
+        rank: 40
+        range: string
+      packageLocation:
+        description: >-
+          DEPRECATED. URL indicating the Compose package's location.
+          Use `repository` and `revision` instead. This field is retained
+          for backward compatibility and MUST NOT be used for new
+          ApplicationDescription documents. Implementations SHOULD support
+          this field during a transition period and emit a deprecation warning.
+          When both `repository` and `packageLocation` are present in a
+          `ComponentProperties` element, the WFM MUST use `repository` and
+          `revision` and MUST ignore `packageLocation`.
+        rank: 50
+        range: string
+        deprecated: >-
+          Deprecated in favor of repository + revision OCI-based publishing.
+          Will be removed in a future version of the specification.
+      keyLocation:
+        description: >-
+          URL for the public key used to validate a digitally signed package.
+          MAY be used when the component artifact is signed (e.g., using cosign or PGP).
+        rank: 60
+        range: string
+```
+
+**Diff**
+
+```diff
+   ComponentProperties:
+     description: Properties dictionary for component deployment details.
+     rank: 80
+     attributes:
+       repository:
+-        description: Repository location for the component.
++        description: >-
++          OCI repository URI for the component (e.g., oci://registry.example.com/org/component-name).
++          MUST be used for Helm, Compose, and Quadlet components.
+         rank: 10
+         range: string
++        required: false  # Becomes required: true in Phase 2 (v1-beta1)
+       revision:
+-        description: Revision version for the component.
++        description: >-
++           OCI tag identifying the component version within the repository (e.g., "1.0.0", "2.3.1").
++           SemVer 2.0 version without leading `v`.
++           MUST be used for Helm, Compose, and Quadlet components.
+         rank: 20
+         range: string
++        required: false  # Becomes required: true in Phase 2 (v1-beta1)
+       wait:
+         description: If True, indicates the device waits for the component installation to complete.
+         rank: 30
+         range: boolean
+       timeout:
+         description: Time to wait for component installation to complete, formatted as "##m##s".
+         rank: 40
+         range: string
+       packageLocation:
+-        description: URL indicating the Compose package's location.
++        description: >-
++          DEPRECATED. URL indicating the Compose package's location.
++          Use `repository` and `revision` instead. This field is retained
++          for backward compatibility and MUST NOT be used for new
++          ApplicationDescription documents. Implementations SHOULD support
++          this field during a transition period and emit a deprecation warning.
++          When both `repository` and `packageLocation` are present in a
++          `ComponentProperties` element, the WFM MUST use `repository` and
++          `revision` and MUST ignore `packageLocation`.
+         rank: 50
+         range: string
++        deprecated: >-
++          Deprecated in favor of repository + revision OCI-based publishing.
++          Will be removed in a future version of the specification.
+       keyLocation:
+-        description: URL for the public key used to validate a digitally signed package.
++        description: >-
++          URL for the public key used to validate a digitally signed package.
++          MAY be used when the component artifact is signed (e.g., using cosign or PGP).
+         rank: 60
+         range: string
+```
+
+---
+
+#### Change 3b: Rename `ComposeDeploymentProfile` type value from `"compose"` to `"compose.v1"`
+
+The bare `"compose"` type value is tied to the legacy `packageLocation` plain-HTTPS model. The new OCI-native publishing model introduced by this proposal uses `"compose.v1"` to signal a versioned, OCI-compliant deployment profile. The legacy `"compose"` value is retained in the regex pattern for backward compatibility during the transition period.
+
+**Before**
+
+```yaml
+  ComposeDeploymentProfile:
+    is_a: DeploymentProfile
+    #rank: 66
+    slot_usage:
+      type:
+        equals_string: "compose"
+        rank: 10
+      components:
+        range: ComposeComponent
+        rank: 20
+```
+
+```yaml
+    pattern: ^(helm\.v3|compose)$
+```
+
+New ApplicationDescription documents MUST use `compose.v1` as the deployment profile type value. Existing documents using `compose` remain valid during the transition period defined in the Backward Compatibility section.
+
+**After**
+
+```yaml
+  ComposeDeploymentProfile:
+    is_a: DeploymentProfile
+    #rank: 66
+    slot_usage:
+      type:
+        equals_string: "compose"
+        rank: 10
+      components:
+        range: ComposeComponent
+        rank: 20
+    deprecated: >-
+      Deprecated in favor of ComposeV1DeploymentProfile.
+      Will be removed in Phase 2 (v1-beta1). Use ComposeV1DeploymentProfile for new documents.
+
+  ComposeV1DeploymentProfile:
+    is_a: DeploymentProfile
+    #rank: 67
+    slot_usage:
+      type:
+        equals_string: "compose.v1"
+        rank: 10
+      components:
+        range: ComposeComponent
+        rank: 20
+```
+
+```yaml
+    pattern: ^(helm\.v3|compose|compose\.v1)$
+```
+
+> **Note:** `ComposeDeploymentProfile` (bare `"compose"`) is retained for backward compatibility during Phase 1 but is deprecated. WFM implementations SHOULD treat `"compose"` as equivalent to `"compose.v1"` with a deprecation warning during the transition period. `ComposeDeploymentProfile` will be removed in Phase 2 (v1-beta1).
+
+**Diff**
+
+```diff
+   ComposeDeploymentProfile:
+     is_a: DeploymentProfile
+     #rank: 66
+     slot_usage:
+       type:
+         equals_string: "compose"
+         rank: 10
+       components:
+         range: ComposeComponent
+         rank: 20
++    deprecated: >-
++      Deprecated in favor of ComposeV1DeploymentProfile.
++      Will be removed in Phase 2 (v1-beta1). Use ComposeV1DeploymentProfile for new documents.
++
++  ComposeV1DeploymentProfile:
++    is_a: DeploymentProfile
++    #rank: 67
++    slot_usage:
++      type:
++        equals_string: "compose.v1"
++        rank: 10
++      components:
++        range: ComposeComponent
++        rank: 20
+```
+
+```diff
+-    pattern: ^(helm\.v3|compose)$
++    pattern: ^(helm\.v3|compose|compose\.v1)$
+```
+
+---
+
+#### Change 3c: Update `type` slot description to document `compose.v1`
+
+##### Affected file
+
+`src/specification/applications/application-description.linkml.yaml` -- slot `type` description
+
+##### Before
+
+```yaml
+  type:
+    description: >-
+          Defines the type of this deployment configuration for the application. 
+          The allowed values are `helm.v3`, to indicate the deployment profile's format is Helm version 3, 
+          and `compose` to indicate the deployment profile's format is a Compose file. 
+          When installing the application on a device supporting the Kubernetes platform, all `helm.v3` components, 
+          and only `helm.v3` components, will be provided to the device in same order they are listed in the application description file. 
+          When installing the application on a device supporting Compose, all `compose` components, 
+          and only `compose` components, will be provided to the device in the same order they are listed in the application description file. 
+          The device will install the components in the same order they are listed in the application description file.
+    range: string
+    required: true
+    pattern: ^(helm\.v3|compose)$
+    rank: 10
+```
+
+##### After
+
+```yaml
+  type:
+    description: >-
+      The deployment profile type discriminator. Allowed values:
+      - `helm.v3`: Helm-based component (see HelmDeploymentProfile).
+      - `compose.v1`: Compose-based component using OCI registry publishing (see ComposeV1DeploymentProfile). Preferred for new documents.
+      - `compose`: Compose-based component (see ComposeDeploymentProfile). Deprecated -- use `compose.v1` for new documents.
+      - `quadlet.v1`: Quadlet-based component (see QuadletDeploymentProfile, introduced by WG-PROPOSAL-02).
+    rank: 10
+    range: string
+    required: true
+    pattern: ^(helm\.v3|compose|compose\.v1|quadlet\.v1)$
+```
+
+##### Diff
+
+```diff
+ slots:
+   type:
+-    description: >-
+-          Defines the type of this deployment configuration for the application. 
+-          The allowed values are `helm.v3`, to indicate the deployment profile's format is Helm version 3, 
+-          and `compose` to indicate the deployment profile's format is a Compose file. 
+-          When installing the application on a device supporting the Kubernetes platform, all `helm.v3` components, 
+-          and only `helm.v3` components, will be provided to the device in same order they are listed in the application description file. 
+-          When installing the application on a device supporting Compose, all `compose` components, 
+-          and only `compose` components, will be provided to the device in the same order they are listed in the application description file. 
+-          The device will install the components in the same order they are listed in the application description file.
+-    range: string
+-    required: true
+-    pattern: ^(helm\.v3|compose)$
++    description: >-
++      The deployment profile type discriminator. Allowed values:
++      - `helm.v3`: Helm-based component (see HelmDeploymentProfile).
++      - `compose.v1`: Compose-based component using OCI registry publishing (see ComposeV1DeploymentProfile). Preferred for new documents.
++      - `compose`: Compose-based component (see ComposeDeploymentProfile). Deprecated -- use `compose.v1` for new documents.
++      - `quadlet.v1`: Quadlet-based component (see QuadletDeploymentProfile, introduced by WG-PROPOSAL-02).
+     rank: 10
++    range: string
++    required: true
++    pattern: ^(helm\.v3|compose|compose\.v1|quadlet\.v1)$
+```
+
+---
+
+### Change 4: Compose Archive Structure (new section in `application-package.md`)
+
+It defines the normative internal structure of Compose Archives.
+
+**New content (addition)**
+
+````markdown
+## Compose Archive Structure
+
+A Compose Archive is a gzip-compressed tar archive (`.tar.gz` or `.tgz`) that packages a [Compose](https://www.compose-spec.io/) application for deployment on edge devices. The archive MUST conform to the following structural requirements.
+
+### Directory Layout
+
+The archive MUST contain exactly one top-level directory. The name of this directory MUST match the component `name` as specified in the [ApplicationDescription](../../specification/applications/application-description.md#component-attributes).
+
+The top-level directory MUST contain a file named `compose.yaml`. The Compose file MUST conform to the [Compose Specification](https://www.compose-spec.io/) as currently published.
+
+> **Note:** The Compose file MUST be named `compose.yaml`. The alternative names `compose.yml`, `docker-compose.yaml`, and `docker-compose.yml` are NOT valid within a Margo Compose Archive. This restriction ensures predictable file discovery by WFM and device implementations.
+
+All files referenced by `compose.yaml` (including but not limited to `env_file` entries, `volumes` bind-mount sources, `configs` file sources, and `secrets` file sources) MUST be included within the archive and MUST be referenced using relative paths that resolve within the top-level directory.
+
+### Security Constraints
+
+- Symlinks MUST NOT target paths outside the top-level directory.
+- Hard links MUST NOT reference paths outside the top-level directory.
+- Absolute paths MUST NOT appear in the archive entries.
+- File names MUST NOT contain path traversal sequences (`../`).
+- Implementations SHOULD normalize file permissions during archive extraction. Implementations MUST NOT preserve setuid, setgid, or sticky bits from archive entries.
+- WFM and device implementations MUST validate these constraints before extracting or deploying the archive.
+
+### Example
+
+```tree
+myapp-1.0.0-compose.tgz
++-- myapp/
+    +-- compose.yaml
+    +-- .env
+    +-- config/
+        +-- app.conf
+```
+
+In this example:
+
+- `myapp` is the component name matching the ApplicationDescription.
+- `compose.yaml` is the required Compose file.
+- `.env` is an environment variable file referenced by `env_file` in `compose.yaml`.
+- `config/app.conf` is a configuration file referenced as a bind mount or config in `compose.yaml`.
+
+### Integrity Verification
+
+When stored in an OCI-compliant Component Registry, the Compose Archive tarball is the content of a single layer blob. Integrity verification at the transport layer is provided by the OCI content-addressable digest as mandated by the [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md), which the Margo Application Registry already requires. No separate `digest` or hash field is needed in the ApplicationDescription.
+
+Implementations MUST verify the OCI digest after pulling the blob and before extracting the archive.
+
+### Publishing Workflow
+
+To publish a Compose Archive to an OCI-compliant Component Registry:
+
+1. Create the `.tar.gz` archive conforming to the directory layout above.
+2. Push the archive as an OCI artifact using `oras push` (or equivalent OCI-compliant tooling):
+
+   ```bash
+   oras push registry.example.com/org/myapp:1.0.0 \
+     --artifact-type application/vnd.org.margo.component.compose.v1+json \
+     myapp-1.0.0-compose.tar.gz:application/vnd.org.margo.component.compose.v1.tar.gzip
+   ```
+
+3. Reference the artifact in the ApplicationDescription:
+
+   ```yaml
+   components:
+     - name: myapp
+       properties:
+         repository: oci://registry.example.com/org/myapp
+         revision: "1.0.0"
+   ```
+
+> **Resolved**: Integrity verification is provided by the OCI content-addressable digest as mandated by the OCI Distribution Specification v1.1.0, which the Margo Application Registry already requires. No separate hash or digest field is required in the ApplicationDescription.
+
+````
+
+---
+
+## Conformance Impact
+
+This proposal introduces the following normative statements:
+
+| RFC 2119 Keyword | Statement |
+|---|---|
+| MUST | Compose Archives MUST be stored in an OCI-compliant Component Registry and referenced via `repository` + `revision`. |
+| MUST | The OCI image manifest for a Compose component MUST use `artifactType` = `application/vnd.org.margo.component.compose.v1+json`. |
+| MUST | The layer blob mediaType for Compose MUST be `application/vnd.org.margo.component.compose.v1.tar.gzip`. |
+| MUST | A Compose Archive MUST contain exactly one top-level directory whose name matches the component `name`. |
+| MUST | A Compose Archive MUST contain a `compose.yaml` file in the top-level directory. |
+| MUST | The `compose.yaml` file MUST conform to the Compose Specification as currently published. |
+| SHOULD | The TWG SHOULD establish a minimum Compose Specification compatibility baseline in a follow-up proposal. |
+| MUST | All files referenced by `compose.yaml` MUST be included within the archive using relative paths. |
+| MUST NOT | Symlinks MUST NOT target paths outside the top-level directory. |
+| MUST NOT | Hard links MUST NOT reference paths outside the top-level directory. |
+| MUST NOT | Absolute paths MUST NOT appear in archive entries. |
+| MUST NOT | File names MUST NOT contain path traversal sequences. |
+| MUST NOT | Implementations MUST NOT preserve setuid, setgid, or sticky bits from archive entries. |
+| MUST | WFM and device implementations MUST validate security constraints before extraction. |
+| MUST | Implementations MUST verify the OCI digest after pulling and before extracting. |
+| MUST NOT | `packageLocation` MUST NOT be used for new ApplicationDescription documents. |
+| MUST | When both `repository` and `packageLocation` are present, the WFM MUST use `repository`/`revision` and MUST ignore `packageLocation`. |
+| SHOULD | Implementations SHOULD support `packageLocation` during a transition period with a deprecation warning. |
+| SHOULD | Implementations SHOULD normalize file permissions during archive extraction. |
+| SHOULD | Authentication for secure registries SHOULD follow the existing Authentication, Authorization & Security section. |
+| MAY | A deployment profile type MAY be omitted if it cannot be implemented. |
+
+---
+
+## Backward Compatibility
+
+### Breaking Changes
+
+1. **`packageLocation` deprecation**: Existing ApplicationDescription documents that use `packageLocation` for Compose components will trigger a deprecation warning. These documents remain valid during the transition period but MUST be migrated to `repository` + `revision` before `packageLocation` is removed in a future spec version.
+
+2. **`repository` and `revision` transition to required**: In Phase 1, both fields are marked `required: false` in the schema to preserve validation compatibility. Existing Compose ApplicationDescription documents that only use `packageLocation` (without `repository`/`revision`) remain schema-valid during Phase 1. In Phase 2 (v1-beta1), both fields become `required: true`, at which point documents lacking these fields will fail schema validation.
+
+3. **Compose Archive structure constraints**: Existing Compose Archives that do not follow the single-top-level-directory convention or that use `docker-compose.yaml` instead of `compose.yaml` will become non-compliant and must be restructured.
+
+### Migration Path
+
+1. Application developers MUST update Compose-based ApplicationDescription documents to use `repository` + `revision` pointing to an OCI registry.
+2. Application developers MUST push their Compose Archives to an OCI registry using `oras push` (or equivalent) with the correct media types.
+3. Application developers MUST restructure their Compose Archives to use a single top-level directory matching the component name, with `compose.yaml` as the entry point.
+4. The `packageLocation` field MAY be retained alongside `repository`/`revision` during the transition period for backward compatibility with older WFM implementations.
+5. WFM implementations SHOULD be updated to resolve components via OCI pull (using `repository` + `revision`) and fall back to `packageLocation` only when `repository` is absent.
+
+### Version Transition Strategy
+
+This proposal adopts a two-phase transition to manage the breaking change introduced by making `repository` and `revision` required.
+
+**Phase 1 (this spec version, pre-draft):** `repository` and `revision` are **SHOULD** for Compose components; `packageLocation` remains valid. The schema sets `required: false` on `repository` and `revision` to preserve validation compatibility with existing documents that use only `packageLocation`. The schema version bumps from v1-alpha1 to v1-alpha2 to signal the change without breaking existing validators. Phase 1 also introduces `ComposeV1DeploymentProfile` (with `equals_string: "compose.v1"`) alongside the existing `ComposeDeploymentProfile` (with `equals_string: "compose"`); both are valid during this phase.
+
+**Phase 2 (v1-beta1 or later):** `repository` and `revision` become **REQUIRED** (`required: true` is set); `packageLocation` is removed from the schema entirely. `ComposeDeploymentProfile` (bare `"compose"`) is removed; only `ComposeV1DeploymentProfile` remains.
+
+> **Note:** Implementations relying solely on `packageLocation` SHOULD migrate during Phase 1. No production backward-compatibility guarantee exists for pre-draft schema versions.
+
+### Version Impact
+
+- The `packageLocation` deprecation, the addition of `ComposeV1DeploymentProfile`, and the Phase 2 promotion of `repository`/`revision` to `required: true` constitute breaking schema changes.
+- The schema version MUST be bumped to reflect the breaking changes introduced by this proposal. The LinkML schema `version` MUST be updated from `1.0` to `1.1` and the API version label from v1-alpha1 to v1-alpha2 accordingly. The Phase 2 promotion to `required: true` will be accompanied by a further version increment to v1-beta1.
+
+---
+
+## References
+
+- [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md)
+- [OCI Image Specification v1.1.0](https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md)
+- [RFC 2119 -- Key words for use in RFCs to Indicate Requirement Levels](https://www.rfc-editor.org/rfc/rfc2119)
+- [RFC 6838 -- Media Type Specifications and Registration Procedures](https://www.rfc-editor.org/rfc/rfc6838)
+- [Compose Specification](https://www.compose-spec.io/)
+- [ORAS (OCI Registry as Storage)](https://oras.land/)
+- WG-PROPOSAL-00: The Helm Way (companion informational document)
+
+---
+
+*This document is part of the Margo WG Compose/Quadlet OCI Publishing proposal package. Prepared by the Andrii Melashchenko (Belden Inc.), 2026-05-04. Subject to the Open Web Foundation Contributor License Agreement governing the Margo specification.*

--- a/proposals/the-helm-way/WG-PROPOSAL-02_quadlet-component-type.md
+++ b/proposals/the-helm-way/WG-PROPOSAL-02_quadlet-component-type.md
@@ -1,0 +1,414 @@
+# WG-PROPOSAL-02: Quadlet Component Type
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-04 |
+| Category | Cat 2 -- normative enhancement |
+| Affects | `system-design/concepts/applications/application-package.md`, `system-design/specification/applications/application-registry.md`, `src/specification/applications/application-description.linkml.yaml` |
+| Status | Rev 1 -- ready for public review |
+| Depends on | WG-PROPOSAL-00 (informational), WG-PROPOSAL-01 (normative, MUST be applied first) |
+
+---
+
+## Motivation
+
+Quadlet is a **key deliverable** for the Margo edge workload model. It provides native systemd integration for container workloads without requiring a full Kubernetes control plane — exactly the lightweight, daemon-free deployment model needed on constrained OT edge devices. Quadlet (Podman 5.0+) is production-ready and already deployed in industrial environments.
+
+This proposal applies The Helm Way pattern (WG-PROPOSAL-00) to Quadlet components. It MUST be applied after WG-PROPOSAL-01, which establishes the OCI registry mandate and Compose support that this proposal extends to Quadlet.
+
+Quadlet -- Podman's native systemd integration format -- is not addressed by the current Margo specification, despite growing adoption in lightweight edge deployments where a full Kubernetes control plane is unnecessary. Quadlet allows containers to be managed as native systemd services, providing:
+
+- Automatic container restart and dependency management via systemd
+- Integration with existing systemd-based monitoring and logging infrastructure
+- Rootless container operation without a daemon process
+- Lightweight footprint suitable for constrained edge devices
+
+This proposal adds Quadlet as a third component type alongside Helm and Compose, following the same OCI-based publishing pattern.
+
+---
+
+## Proposed Changes
+
+### Change 1: `system-design/concepts/applications/application-package.md`
+
+#### Change 1a: Add Quadlet bullet to component type list
+
+This change adds the Quadlet component bullet to the existing component type list. It MUST be applied after WG-PROPOSAL-01's Change 1b, which rewrites the Helm and Compose bullets.
+
+**New bullet (inserted after Compose bullet)**
+
+```markdown
+- To target devices which deploy workloads using [Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html), components MUST be packaged as Quadlet Archives (see [Quadlet Archive Structure](#quadlet-archive-structure) below) and stored in an OCI-compliant [Component Registry](../../personas-and-definitions/technical-lexicon.md#component-registry). The Quadlet Archive MUST be pushed to the registry as an OCI artifact and referenced via `repository` (an `oci://` URI) and `revision` (an OCI tag) in the [ApplicationDescription](../../specification/applications/application-description.md#componentproperties-attributes). The OCI image manifest for the artifact MUST use `application/vnd.org.margo.component.quadlet.v1+json` as its `artifactType`, and the layer blob containing the tarball MUST use `application/vnd.org.margo.component.quadlet.v1.tar.gzip` as its `mediaType`. Integrity is provided by the OCI content-addressable digest as mandated by the [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md), which the Margo Application Registry already requires. The target device MUST have Podman 5.0 or later installed to support Quadlet deployment.
+```
+
+**Diff** (applied after WG-PROPOSAL-01's Change 1b)
+
+```diff
+ - To target devices which deploy workloads using [Compose](https://www.compose-spec.io/), components MUST be packaged as [Compose Archives](...) ...
++- To target devices which deploy workloads using [Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html), components MUST be packaged as Quadlet Archives (see [Quadlet Archive Structure](#quadlet-archive-structure) below) and stored in an OCI-compliant [Component Registry](../../personas-and-definitions/technical-lexicon.md#component-registry). The Quadlet Archive MUST be pushed to the registry as an OCI artifact and referenced via `repository` (an `oci://` URI) and `revision` (an OCI tag) in the [ApplicationDescription](../../specification/applications/application-description.md#componentproperties-attributes). The OCI image manifest for the artifact MUST use `application/vnd.org.margo.component.quadlet.v1+json` as its `artifactType`, and the layer blob containing the tarball MUST use `application/vnd.org.margo.component.quadlet.v1.tar.gzip` as its `mediaType`. Integrity is provided by the OCI content-addressable digest as mandated by the [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md), which the Margo Application Registry already requires. The target device MUST have Podman 5.0 or later installed to support Quadlet deployment.
+```
+
+---
+
+### Change 2: `system-design/specification/applications/application-registry.md`
+
+#### Change 2a: Add Quadlet media types to Component Registry Media Types table
+
+These two rows MUST be added to the Component Registry Media Types subtable introduced by WG-PROPOSAL-01 Change 2a.
+
+**New rows**
+
+```markdown
+|``application/vnd.org.margo.component.quadlet.v1+json``| MUST be used as the **artifactType** to mark an OCI image manifest as a Margo Quadlet Archive component in a Component Registry |
+|``application/vnd.org.margo.component.quadlet.v1.tar.gzip``| MUST be used as the **mediaType** for the layer blob containing the Quadlet Archive tarball (.tar.gz) |
+```
+
+**Diff** (appended to the Component Registry Media Types table from WG-PROPOSAL-01)
+
+```diff
+ |``application/vnd.org.margo.component.compose.v1+json``| MUST be used as the **artifactType** to mark an OCI image manifest as a Margo Compose Archive component in a Component Registry |
+ |``application/vnd.org.margo.component.compose.v1.tar.gzip``| MUST be used as the **mediaType** for the layer blob containing the Compose Archive tarball (.tar.gz) |
++|``application/vnd.org.margo.component.quadlet.v1+json``| MUST be used as the **artifactType** to mark an OCI image manifest as a Margo Quadlet Archive component in a Component Registry |
++|``application/vnd.org.margo.component.quadlet.v1.tar.gzip``| MUST be used as the **mediaType** for the layer blob containing the Quadlet Archive tarball (.tar.gz) |
+```
+
+---
+
+### Change 3: `src/specification/applications/application-description.linkml.yaml`
+
+#### Change 3a: Add `QuadletDeploymentProfile` and `QuadletComponent` classes
+
+**Before** (after `ComposeDeploymentProfile` and `ComposeComponent`)
+
+```yaml
+  ComposeDeploymentProfile:
+    is_a: DeploymentProfile
+    #rank: 66
+    slot_usage:
+      type:
+        equals_string: "compose.v1"
+        rank: 10
+      components:
+        range: ComposeComponent
+        rank: 20
+
+  # ... Component class ...
+
+  ComposeComponent:
+    is_a: Component
+    #rank: 76
+```
+
+> **Note:** The Before block reflects the state after WG-PROPOSAL-01 has been applied, which renames the `type` value from `"compose"` (legacy) to `"compose.v1"`.
+
+**After**
+
+```yaml
+  ComposeDeploymentProfile:
+    is_a: DeploymentProfile
+    #rank: 66
+    slot_usage:
+      type:
+        equals_string: "compose.v1"
+        rank: 10
+      components:
+        range: ComposeComponent
+        rank: 20
+
+  QuadletDeploymentProfile:
+    is_a: DeploymentProfile
+    description: >-
+      Deployment profile for Quadlet-based workloads targeting devices running
+      Podman 5.0 or later with systemd integration.
+    #rank: 67
+    slot_usage:
+      type:
+        equals_string: "quadlet.v1"
+        rank: 10
+      components:
+        range: QuadletComponent
+        rank: 20
+
+  # ... Component class ...
+
+  ComposeComponent:
+    is_a: Component
+    #rank: 76
+
+  QuadletComponent:
+    is_a: Component
+    description: >-
+      A component packaged as a Quadlet Archive for deployment on devices
+      using Podman with systemd integration. The archive is stored in an
+      OCI-compliant Component Registry and referenced via repository and
+      revision. The OCI image manifest for this component type uses
+      artifactType application/vnd.org.margo.component.quadlet.v1+json
+      (see application-registry.md).
+    #rank: 77
+```
+
+**Diff**
+
+```diff
+   ComposeDeploymentProfile:
+     is_a: DeploymentProfile
+     #rank: 66
+     slot_usage:
+       type:
+         equals_string: "compose.v1"
+         rank: 10
+       components:
+         range: ComposeComponent
+         rank: 20
+
++  QuadletDeploymentProfile:
++    is_a: DeploymentProfile
++    description: >-
++      Deployment profile for Quadlet-based workloads targeting devices running
++      Podman 5.0 or later with systemd integration.
++    #rank: 67
++    slot_usage:
++      type:
++        equals_string: "quadlet.v1"
++        rank: 10
++      components:
++        range: QuadletComponent
++        rank: 20
++
+   Component:
+     description: A class representing a component of a deployment profile.
+     ...
+
+   ComposeComponent:
+     is_a: Component
+     #rank: 76
+-  
++
++  QuadletComponent:
++    is_a: Component
++    description: >-
++      A component packaged as a Quadlet Archive for deployment on devices
++      using Podman with systemd integration. The archive is stored in an
++      OCI-compliant Component Registry and referenced via repository and
++      revision. The OCI image manifest for this component type uses
++      artifactType application/vnd.org.margo.component.quadlet.v1+json
++      (see application-registry.md).
++    #rank: 77
+```
+
+---
+
+#### Change 3b: Add `quadlet.v1` to `type` slot pattern
+
+> **Note:** WG-PROPOSAL-01 Change 3c replaces the `type` slot description with a bullet-list format and already includes `quadlet.v1`. Therefore, this change only updates the regex pattern. No description change is needed here; P-01 Change 3c is sufficient.
+
+**Before** (after WG-PROPOSAL-01 Change 3c has been applied)
+
+```yaml
+  type:
+    description: >-
+      The deployment profile type discriminator. Allowed values:
+      - `helm.v3`: Helm-based component (see HelmDeploymentProfile).
+      - `compose.v1`: Compose-based component using OCI registry publishing (see ComposeV1DeploymentProfile). Preferred for new documents.
+      - `compose`: Compose-based component (see ComposeDeploymentProfile). Deprecated -- use `compose.v1` for new documents.
+      - `quadlet.v1`: Quadlet-based component (see QuadletDeploymentProfile, introduced by WG-PROPOSAL-02).
+    rank: 10
+    range: string
+    required: true
+    pattern: ^(helm\.v3|compose|compose\.v1)$
+```
+
+**After**
+
+```yaml
+  type:
+    description: >-
+      The deployment profile type discriminator. Allowed values:
+      - `helm.v3`: Helm-based component (see HelmDeploymentProfile).
+      - `compose.v1`: Compose-based component using OCI registry publishing (see ComposeV1DeploymentProfile). Preferred for new documents.
+      - `compose`: Compose-based component (see ComposeDeploymentProfile). Deprecated -- use `compose.v1` for new documents.
+      - `quadlet.v1`: Quadlet-based component (see QuadletDeploymentProfile, introduced by WG-PROPOSAL-02).
+    rank: 10
+    range: string
+    required: true
+    pattern: ^(helm\.v3|compose|compose\.v1|quadlet\.v1)$
+```
+
+**Diff**
+
+```diff
+   type:
+     description: >-
+       The deployment profile type discriminator. Allowed values:
+       ...
+       - `quadlet.v1`: Quadlet-based component (see QuadletDeploymentProfile, introduced by WG-PROPOSAL-02).
+     rank: 10
+     range: string
+     required: true
+-    pattern: ^(helm\.v3|compose|compose\.v1)$
++    pattern: ^(helm\.v3|compose|compose\.v1|quadlet\.v1)$
+```
+
+---
+
+### Change 4: Quadlet Archive Structure (new section in `application-package.md`)
+
+This section defines the normative archive structure for `quadlet.v1` components, complementing the Compose Archive Structure defined in WG-PROPOSAL-01. It defines the normative internal structure of Quadlet Archives.
+
+**New content (addition)**
+
+````markdown
+## Quadlet Archive Structure
+
+A Quadlet Archive is a gzip-compressed tar archive (`.tar.gz` or `.tgz`) that packages a set of [Podman Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) unit files for deployment on edge devices running Podman 5.0 or later with systemd integration. The archive MUST conform to the following structural requirements.
+
+### Directory Layout
+
+The archive MUST contain exactly one top-level directory. The name of this directory MUST match the component `name` as specified in the [ApplicationDescription](../../specification/applications/application-description.md#component-attributes).
+
+The top-level directory MAY contain Quadlet unit files according to [Podman Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html).
+
+### Security Constraints
+
+- Symlinks MUST NOT target paths outside the top-level directory.
+- Hard links MUST NOT reference paths outside the top-level directory.
+- Absolute paths MUST NOT appear in the archive entries.
+- File names MUST NOT contain path traversal sequences (`../`).
+- Implementations SHOULD normalize file permissions during archive extraction. Implementations MUST NOT preserve setuid, setgid, or sticky bits from archive entries.
+- WFM and device implementations MUST validate these constraints before extracting or deploying the archive.
+
+### Example
+
+```tree
+
+myapp-1.0.0-quadlet.tgz
++-- myapp/
+    +-- myapp.container
+    +-- myapp.network
+    +-- myapp.volume
+
+```
+
+In this example:
+
+- `myapp` is the component name matching the ApplicationDescription.
+- `myapp.container` is the primary Quadlet container unit.
+- `myapp.network` defines a Podman network for the container.
+- `myapp.volume` defines a Podman volume for persistent storage.
+
+### Multi-Container Quadlet Example
+
+For applications requiring multiple containers:
+
+```tree
+
+my-platform-1.0.0-quadlet.tgz
++-- my-platform/
+    +-- frontend.container
+    +-- backend.container
+    +-- database.container
+    +-- app.network
+    +-- db-data.volume
+    +-- config/
+        +-- backend.env
+
+```
+
+### Integrity Verification
+
+When stored in an OCI-compliant Component Registry (as mandated by this specification), the Quadlet Archive tarball is the content of a single layer blob. Integrity verification at the transport layer is provided by the OCI content-addressable digest as mandated by the [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md), which the Margo Application Registry already requires.
+
+Implementations MUST verify the OCI digest after pulling the blob and before extracting the archive.
+
+### Publishing Workflow
+
+To publish a Quadlet Archive to an OCI-compliant Component Registry:
+
+1. Create the `.tar.gz` archive conforming to the directory layout above.
+2. Push the archive as an OCI artifact:
+
+   ```bash
+   oras push registry.example.com/org/myapp:1.0.0 \
+     --artifact-type application/vnd.org.margo.component.quadlet.v1+json \
+     myapp-1.0.0-quadlet.tar.gz:application/vnd.org.margo.component.quadlet.v1.tar.gzip
+   ```
+
+3. Reference the artifact in the ApplicationDescription:
+
+   ```yaml
+   components:
+     - name: myapp
+       properties:
+         repository: oci://registry.example.com/org/myapp
+         revision: "1.0.0"
+   ```
+
+````
+
+---
+
+## Companion Artifact
+
+A companion patch (`PATCH_desired-state-quadlet.diff`) is provided with this proposal package to apply the required desired-state schema changes. That patch adds `QuadletDeploymentProfile` and `QuadletComponent` to `desired-state.linkml.yaml` and MUST be applied before Quadlet workloads can be deployed via the Margo Management Interface.
+
+---
+
+## Conformance Impact
+
+This proposal introduces the following normative statements:
+
+| RFC 2119 Keyword | Statement |
+|---|---|
+| MUST | Quadlet Archives MUST be stored in an OCI-compliant Component Registry and referenced via `repository` + `revision`. |
+| MUST | The OCI image manifest for a Quadlet component MUST use `artifactType` = `application/vnd.org.margo.component.quadlet.v1+json`. |
+| MUST | The layer blob mediaType for Quadlet MUST be `application/vnd.org.margo.component.quadlet.v1.tar.gzip`. |
+| MUST | A Quadlet Archive MUST contain exactly one top-level directory whose name matches the component `name`. |
+| MUST | The target device MUST have Podman 5.0 or later installed to support Quadlet deployment. |
+| MUST NOT | Symlinks MUST NOT target paths outside the top-level directory. |
+| MUST NOT | Hard links MUST NOT reference paths outside the top-level directory. |
+| MUST NOT | Absolute paths MUST NOT appear in archive entries. |
+| MUST NOT | File names MUST NOT contain path traversal sequences. |
+| MUST NOT | Implementations MUST NOT preserve setuid, setgid, or sticky bits from archive entries. |
+| MUST | WFM and device implementations MUST validate security constraints before extraction. |
+| MUST | Implementations MUST verify the OCI digest after pulling and before extracting. |
+| SHOULD | Implementations SHOULD normalize file permissions during archive extraction. |
+
+---
+
+## Backward Compatibility
+
+### Breaking Changes
+
+This proposal is **additive only**. It does not modify any existing normative text or schema constraint that would break existing implementations.
+
+- The `type` regex expansion from `^(helm\.v3|compose|compose\.v1)$` to `^(helm\.v3|compose|compose\.v1|quadlet\.v1)$` is additive -- existing documents with `type: helm.v3`, `type: compose`, or `type: compose.v1` continue to validate.
+- The new `QuadletDeploymentProfile` and `QuadletComponent` classes are additions to the schema class hierarchy -- no existing class is modified.
+- The new Quadlet media types are additions to the media type table -- no existing media type is changed.
+- The Quadlet Archive Structure section is entirely new normative text.
+
+**Breaking change: NO** (when considered independently of WG-PROPOSAL-01).
+
+### Migration Path
+
+No migration is needed for existing implementations. Quadlet is a greenfield addition:
+
+- Existing Helm and Compose ApplicationDescription documents are unaffected.
+- Existing WFM implementations that do not support Quadlet will ignore `type: quadlet.v1` deployment profiles per the existing spec behavior (unknown types are skipped).
+- Edge devices without Podman 5.0+ will not receive Quadlet deployment profiles.
+
+---
+
+## References
+
+- [Podman Quadlet Documentation](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html)
+- [OCI Distribution Specification v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md)
+- [OCI Image Specification v1.1.0](https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md)
+- [RFC 2119 -- Key words for use in RFCs to Indicate Requirement Levels](https://www.rfc-editor.org/rfc/rfc2119)
+- [ORAS (OCI Registry as Storage)](https://oras.land/)
+- WG-PROPOSAL-00: The Helm Way (companion informational document)
+- WG-PROPOSAL-01: Compose OCI Registry Publishing and Archive Structure (prerequisite normative document)
+- PATCH_desired-state-quadlet.diff (companion schema patch)
+
+---
+
+*This document is part of the Margo WG Compose/Quadlet OCI Publishing proposal package. Prepared by the Andrii Melashchenko, 2026-05-04. Subject to the Open Web Foundation Contributor License Agreement governing the Margo specification.*

--- a/proposals/the-helm-way/WG-PROPOSAL-03_apiversion-evolution-strategy.md
+++ b/proposals/the-helm-way/WG-PROPOSAL-03_apiversion-evolution-strategy.md
@@ -1,0 +1,294 @@
+# WG-PROPOSAL-04: API Version Evolution Strategy
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-05 |
+| Category | Cat 2 -- normative enhancement |
+| Affects | `src/specification/applications/application-description.linkml.yaml`, `src/specification/margo-management-interface/desired-state.linkml.yaml`, `system-design/specification/applications/application-description.md` |
+| Status | Rev 2 -- ready for public review |
+| Depends on | None (independent of WG-PROPOSAL-00 through WG-PROPOSAL-03) |
+
+---
+
+## Motivation
+
+The `apiVersion` field is required in both `ApplicationDescription` and `DesiredState` documents. Current examples use `margo.org/v1-alpha1` and `application.margo.org/v1alpha1` respectively. However, the specification provides:
+
+1. **No version catalogue** -- there is no normative list of valid `apiVersion` values or their lifecycle state (alpha, beta, GA, deprecated).
+2. **No schema constraint** -- the LinkML schema declares `apiVersion` as `range: string` with no pattern or enum. Any arbitrary string validates.
+3. **No migration path** -- no defined WFM behaviour when encountering an unknown or deprecated `apiVersion`.
+4. **No deprecation policy** -- no contract for how long old versions remain supported or how consumers are notified of upcoming removal.
+5. **No backward/forward compatibility contract** -- no guarantee that a minor version bump preserves existing fields.
+
+Without these, WFM implementations cannot determine whether they support a given document, breaking changes have no signalling mechanism, and the ecosystem cannot evolve safely.
+
+---
+
+## Proposed Changes
+
+### Change 1: Add `pattern` constraint to `apiVersion` in `application-description.linkml.yaml`
+
+#### Affected file
+
+`src/specification/applications/application-description.linkml.yaml` -- class `ApplicationDescription`, attribute `apiVersion`
+
+#### Before
+
+```yaml
+  ApplicationDescription:
+    description: Root class for an application description.
+    attributes:
+      apiVersion:
+        description: Identifier of the version of the API the object definition follows.
+        required: true
+        range: string
+        rank: 10
+```
+
+#### After
+
+```yaml
+  ApplicationDescription:
+    description: Root class for an application description.
+    attributes:
+      apiVersion:
+        description: >-
+          Identifier of the version of the API the object definition follows.
+          The value MUST match the pattern `margo.org/v<major>-<lifecycle><revision>`
+          where `<major>` is a positive integer, `<lifecycle>` is one of `alpha`
+          or `beta`, and `<revision>` is a positive integer. The lifecycle
+          qualifier and revision MAY be omitted for stable GA releases, yielding the
+          short form `margo.org/v<major>`. Examples: `margo.org/v1-alpha1`,
+          `margo.org/v1-beta2`, `margo.org/v1`, `margo.org/v2-alpha1`.
+          See the API Version Lifecycle section in the specification for the
+          normative version catalogue and compatibility guarantees.
+        required: true
+        range: string
+        pattern: "^margo\\.org/v[1-9][0-9]*(-(alpha|beta)[1-9][0-9]*)?$"
+        rank: 10
+```
+
+#### Diff
+
+```diff
+   ApplicationDescription:
+     description: Root class for an application description.
+     attributes:
+       apiVersion:
+-        description: Identifier of the version of the API the object definition follows.
++        description: >-
++          Identifier of the version of the API the object definition follows.
++          The value MUST match the pattern `margo.org/v<major>-<lifecycle><revision>`
++          where `<major>` is a positive integer, `<lifecycle>` is one of `alpha`
++          or `beta`, and `<revision>` is a positive integer. The lifecycle
++          qualifier and revision MAY be omitted for stable GA releases, yielding the
++          short form `margo.org/v<major>`. Examples: `margo.org/v1-alpha1`,
++          `margo.org/v1-beta2`, `margo.org/v1`, `margo.org/v2-alpha1`.
++          See the API Version Lifecycle section in the specification for the
++          normative version catalogue and compatibility guarantees.
+         required: true
+         range: string
++        pattern: "^margo\\.org/v[1-9][0-9]*(-(alpha|beta)[1-9][0-9]*)?$"
+         rank: 10
+```
+
+---
+
+### Change 2: Add `pattern` constraint to `apiVersion` in `desired-state.linkml.yaml`
+
+#### Affected file
+
+`src/specification/margo-management-interface/desired-state.linkml.yaml` -- class `DesiredState`, attribute `apiVersion`
+
+#### Before
+
+```yaml
+  DesiredState:
+    description: A class representing the desired state of an entity.
+    attributes:
+      apiVersion:
+        description: Identifier of the version of the API the object definition follows.
+        required: true
+        range: string
+        rank: 10
+```
+
+#### After
+
+```yaml
+  DesiredState:
+    description: A class representing the desired state of an entity.
+    attributes:
+      apiVersion:
+        description: >-
+          Identifier of the version of the API the object definition follows.
+          The value MUST match the pattern
+          `application.margo.org/v<major><lifecycle><revision>` where `<major>`
+          is a positive integer, `<lifecycle>` is one of `alpha` or `beta`,
+          and `<revision>` is a positive integer. The lifecycle
+          qualifier and revision MAY be omitted for stable GA releases.
+          Examples: `application.margo.org/v1alpha1`,
+          `application.margo.org/v1beta2`, `application.margo.org/v1`.
+        required: true
+        range: string
+        pattern: "^application\\.margo\\.org/v[1-9][0-9]*((alpha|beta)[1-9][0-9]*)?$"
+        rank: 10
+```
+
+#### Diff
+
+```diff
+   DesiredState:
+     description: A class representing the desired state of an entity.
+     attributes:
+       apiVersion:
+-        description: Identifier of the version of the API the object definition follows.
++        description: >-
++          Identifier of the version of the API the object definition follows.
++          The value MUST match the pattern
++          `application.margo.org/v<major><lifecycle><revision>` where `<major>`
++          is a positive integer, `<lifecycle>` is one of `alpha` or `beta`,
++          and `<revision>` is a positive integer. The lifecycle
++          qualifier and revision MAY be omitted for stable GA releases.
++          Examples: `application.margo.org/v1alpha1`,
++          `application.margo.org/v1beta2`, `application.margo.org/v1`.
+         required: true
+         range: string
++        pattern: "^application\\.margo\\.org/v[1-9][0-9]*((alpha|beta)[1-9][0-9]*)?$"
+         rank: 10
+```
+
+---
+
+### Change 3: Add API Version Lifecycle section to `application-description.md`
+
+#### Affected file
+
+`system-design/specification/applications/application-description.md` -- new section appended before the existing "Examples" section (or at end of normative text)
+
+#### Before
+
+No API version lifecycle section exists in the specification.
+
+#### After
+
+New normative section:
+
+````markdown
+## API Version Lifecycle
+
+### Version Catalogue
+
+The following table defines all valid `apiVersion` values for `ApplicationDescription` documents and their lifecycle state:
+
+| `apiVersion` value | Lifecycle | Status | Introduced | Deprecated | Removed |
+|---|---|---|---|---|---|
+| `margo.org/v1-alpha1` | Alpha | **Current** | 2024-Q4 | — | — |
+
+> **Note**
+> This table is the normative registry. New versions MUST be added here before implementations may produce or consume them.
+
+The following table defines all valid `apiVersion` values for `DesiredState` documents and their lifecycle state:
+
+| `apiVersion` value | Lifecycle | Status | Introduced | Deprecated | Removed |
+|---|---|---|---|---|---|
+| `application.margo.org/v1alpha1` | Alpha | **Current** | 2024-Q4 | — | — |
+
+> **Note**
+> This table is the normative registry for DesiredState documents. New versions MUST be added here before implementations may produce or consume them.
+
+### Lifecycle States
+
+```mermaid
+stateDiagram-v2
+    [*] --> Alpha
+    Alpha --> Beta : stability criteria met
+    Beta --> Stable : no breaking changes for 2 releases
+    Stable --> Deprecated : successor reaches Stable
+    Deprecated --> Removed : after minimum support window
+    Removed --> [*]
+```
+
+| State | Guarantees | Minimum support window |
+|---|---|---|
+| Alpha | No backward compatibility guaranteed. Fields MAY be added, changed, or removed between alpha revisions. | None -- MAY be removed without notice. |
+| Beta | Backward compatible within the same major version. Fields MUST NOT be removed; new required fields MUST have defaults. | 6 months after successor reaches Beta or Stable. |
+| Stable (GA) | Full backward compatibility within the major version. Only additive changes permitted. | 12 months after successor major version reaches Stable. |
+| Deprecated | Functionally equivalent to Stable. Implementations SHOULD emit a warning when processing deprecated versions. | Remainder of the minimum support window. |
+| Removed | Implementations MUST reject documents with a removed `apiVersion`. | N/A |
+
+### WFM Behaviour Requirements
+
+1. A WFM receiving an `ApplicationDescription` with an `apiVersion` it does not support MUST reject the document with a clear error indicating the unsupported version and listing the versions it supports.
+2. When rejecting a document per requirement #1, the WFM MUST include in its error response a machine-readable error code (e.g., `UNSUPPORTED_API_VERSION`) and a human-readable message listing the `apiVersion` values it supports. The exact serialisation format of the error response is defined by the Management Interface specification.
+3. A WFM MUST NOT silently ignore an unrecognised `apiVersion`.
+4. A WFM processing a deprecated `apiVersion` MUST accept the document but SHOULD emit a warning to the operator indicating the deprecation and the recommended migration target.
+5. A WFM MAY support multiple `apiVersion` values simultaneously to enable rolling upgrades. A WFM supporting multiple versions per this requirement MUST still reject any version not in its supported set per requirement #1.
+
+### Compatibility Rules
+
+1. **Within a major version (stable)**: Only additive, non-breaking changes are permitted. New optional fields MAY be added. Existing fields MUST NOT be removed or have their semantics changed.
+2. **Major version bump**: Breaking changes (field removal, semantic changes, structural reorganisation) MUST increment the major version number.
+3. **Alpha/Beta**: Pre-stable versions carry no cross-revision compatibility guarantee. Implementors SHOULD treat alpha/beta versions as experimental.
+
+### Migration Guidance
+
+When a new major version is released:
+
+1. The previous stable version enters Deprecated state.
+2. Application vendors SHOULD publish ApplicationDescription documents targeting both the deprecated and new versions during the transition window.
+3. WFM implementations MUST support the deprecated version for the minimum support window defined above.
+4. After the support window expires, the deprecated version enters Removed state and implementations MAY drop support.
+
+````
+
+---
+
+## Backward Compatibility
+
+### Breaking Changes
+
+This proposal introduces a `pattern` constraint on `apiVersion` that existing valid documents already satisfy:
+
+- `margo.org/v1-alpha1` matches `^margo\.org/v[1-9][0-9]*(-(alpha|beta)[1-9][0-9]*)?$`
+- `application.margo.org/v1alpha1` matches `^application\.margo\.org/v[1-9][0-9]*((alpha|beta)[1-9][0-9]*)?$`
+
+> The format difference between the two patterns — hyphen-separated lifecycle in `margo.org/v1-alpha1` and concatenated lifecycle in `application.margo.org/v1alpha1` — is a pre-existing divergence that this proposal preserves for backward compatibility. Harmonisation of these formats is tracked in OQ-1.
+
+Documents using arbitrary strings that do not match the pattern will fail validation. This is intentional -- such documents were never interoperable.
+
+**Breaking change: NO** for conforming implementations. **YES** for non-conforming documents using arbitrary `apiVersion` strings.
+
+### Migration Path
+
+- Existing `ApplicationDescription` documents using `apiVersion: margo.org/v1-alpha1` require no changes.
+- Existing `DesiredState` documents using `apiVersion: application.margo.org/v1alpha1` require no changes.
+- WFM implementations MUST be updated to validate the `apiVersion` pattern and implement the reject/warn behaviour defined in Change 3.
+
+---
+
+## Conformance Impact
+
+| Requirement | Level | Who | Condition |
+|-------------|-------|-----|-----------|
+| `apiVersion` MUST match the defined pattern | MUST | ApplicationDescription producers | Always |
+| `apiVersion` MUST match the defined pattern | MUST | DesiredState producers | Always |
+| WFM MUST reject unsupported `apiVersion` | MUST | WFM implementations | On receiving unrecognised version |
+| WFM MUST NOT silently ignore unrecognised `apiVersion` | MUST | WFM implementations | Always |
+| WFM processing deprecated `apiVersion` MUST accept but SHOULD warn | MUST/SHOULD | WFM implementations | On receiving deprecated version |
+| WFM MAY support multiple `apiVersion` values simultaneously | MAY | WFM implementations | Optional |
+| New `apiVersion` values MUST be added to the Version Catalogue before use | MUST | Margo WG | Before publishing new version |
+
+---
+
+## References
+
+- **Gap: No apiVersion evolution strategy** -- prior to this proposal, the Margo specification provided no normative version catalogue, no schema pattern constraint, no WFM rejection/warning behaviour, and no deprecation policy for `apiVersion` values in `ApplicationDescription` and `DesiredState` documents.
+- [Kubernetes API Versioning](https://kubernetes.io/docs/reference/using-api/#api-versioning) -- prior art for alpha/beta/stable lifecycle
+- [RFC 2119 -- Key words for use in RFCs to Indicate Requirement Levels](https://www.rfc-editor.org/rfc/rfc2119)
+- [LinkML Pattern Constraint](https://linkml.io/linkml-model/latest/docs/pattern/) -- schema enforcement mechanism
+- [Semantic Versioning 2.0.0](https://semver.org/) -- general versioning prior art
+
+---
+
+*This document is part of the Margo WG proposal package. Prepared by Andrii Melashchenko, 2026-05-05. Subject to the Open Web Foundation Contributor License Agreement governing the Margo specification.*


### PR DESCRIPTION
The Margo specification already provides a mature, OCI-native publishing workflow for Helm-based components. This document names that workflow "The Helm Way" and distills it into five reusable elements so that future component types (Compose, Quadlet, or any type added later) can reference a single, well-defined pattern rather than repeating the same requirements in every proposal. 