### PR TITLE
SUP: retain `apiVersion` attribute and remove `kind` attribute in ApplicationDescription

### DIFF
--- a/proposals/sup_apiversion_app_description_deployment.md
+++ b/proposals/sup_apiversion_app_description_deployment.md
@@ -1,0 +1,73 @@
+# Specification Update Proposal
+
+## Owner
+
+@vireshnavalli
+
+## Summary
+
+Retain the `apiVersion` attribute in `ApplicationDescription` and `ApplicationDeployment` structures. Although API routes include the version within the URL path, keeping the apiVersion in these structures provides explicit version information and ensures consistency with semantic versioning requirements.
+
+## Reason for proposal
+
+As API routes include version within URL, there is debate about the necessity of explicitly having 'apiVersion' attribute for margo specified REST APIs. However, maintaining the apiVersion in ApplicationDescription and ApplicationDeployment provides:
+
+1. Explicit version tracking at the application definition level
+2. Clear semantic versioning compliance
+3. Version information available without parsing URL paths
+4. Better consistency across specification structures
+5. Addresses specification issue #134
+
+## Requirements alignment acknowledgement
+
+This SUP aligns with the margo specification requirements for clear API versioning and semantic versioning practices. The apiVersion attribute ensures that application descriptions and deployments carry explicit version information, improving clarity and consistency across the specification.
+
+**Related Feature(s):** [Issue #134 - margo/specification](https://github.com/margo/specification/issues/134)
+
+## Technical proposal
+
+### Changes to ApplicationDescription
+
+Retain the `apiVersion` field in the `ApplicationDescription` schema:
+
+```yaml
+ApplicationDescription:
+  type: object
+  properties:
+    apiVersion:
+      type: string
+      description: Semantic version of the application API specification
+      example: "1.0.0"
+    # ... other properties
+```
+
+### Changes to ApplicationDeployment
+
+Retain the `apiVersion` field in the `ApplicationDeployment` schema:
+
+```yaml
+ApplicationDeployment:
+  type: object
+  properties:
+    apiVersion:
+      type: string
+      description: Semantic version of the application API specification
+      example: "1.0.0"
+    # ... other properties
+```
+
+### Version Consistency
+
+- The `apiVersion` value must match the OpenAPI specification version
+- Must follow semantic versioning format (MAJOR.MINOR.PATCH)
+- Should be maintained in sync with API route versioning
+
+## Alternatives considered
+
+1. **Remove apiVersion entirely** - Rejected because it removes explicit version information from application definitions, making it harder to track versioning at the application level without parsing URL routes.
+
+2. **Include version only in API routes** - Rejected because it provides insufficient version metadata in application descriptors and deployment configurations.
+
+## Related PRs
+
+- margo/specification PR #189: "chore: retains apiversion in app description and app deployments"

--- a/proposals/sup_apiversion_app_description_deployment.md
+++ b/proposals/sup_apiversion_app_description_deployment.md
@@ -64,9 +64,8 @@ ApplicationDeployment:
 
 ## Alternatives considered
 
-1. **Remove apiVersion entirely** - Rejected because it removes explicit version information from application definitions, making it harder to track versioning at the application level without parsing URL routes.
+1. **Remove apiVersion entirely** - Rejected because it removes explicit version information from application definitions (application description) and application deployment manifest, making it harder to track versioning at the application description/deployment manifests. Remove apiVersion from the body of the API requests as it is part of the API route, keep the apiVersion in ApplicationDescription (and ApplicationDeployment)
 
-2. **Include version only in API routes** - Rejected because it provides insufficient version metadata in application descriptors and deployment configurations.
 
 ## Related PRs
 

--- a/proposals/sup_apiversion_app_description_deployment.md
+++ b/proposals/sup_apiversion_app_description_deployment.md
@@ -40,8 +40,8 @@ It is an independent document  version identifier.
 
 | Document | apiVersion value |
 |---|---|
-| `ApplicationDescription` | `margo.org/v1alpha1` |
-| `ApplicationDeployment` | `application.margo.org/v1alpha1` |
+| `ApplicationDescription` | `v1alpha1` |
+| `ApplicationDeployment` | `v1alpha1` |
 
 These values are **independent** of:
 - OpenAPI spec version (`1.0.0`)
@@ -65,8 +65,8 @@ ApplicationDescription:
         This is independent of the OpenAPI specification version and API route version.
         MUST be one of the Margo defined stable value.
       enum:
-        - margo.org/v1alpha1
-      example: margo.org/v1alpha1
+        - v1alpha1
+      example: v1alpha1
     kind:
       type: string
       enum: [ApplicationDescription]
@@ -91,8 +91,8 @@ ApplicationDeployment:
         This is independent of the OpenAPI specification version and API route version.
         MUST be one of the Margo defined stable value.
       enum:
-        - application.margo.org/v1alpha1
-      example: application.margo.org/v1alpha1
+        - v1alpha1
+      example: v1alpha1
     kind:
       type: string
       enum: [ApplicationDeployment]
@@ -108,9 +108,9 @@ The progression path for breaking changes is:
 
 | Stage | ApplicationDescription | ApplicationDeployment |
 |---|---|---|
-| Current | `margo.org/v1alpha1` | `application.margo.org/v1alpha1` |
-| Next breaking change | `margo.org/v1alpha2` | `application.margo.org/v1alpha2` |
-| Stable release | `margo.org/v1` | `application.margo.org/v1` |
+| Current | `v1alpha1` | `v1alpha1` |
+| Next breaking change | `v1alpha2` | `v1alpha2` |
+| Stable release | `v1` | `v1` |
 
 **Rules:**
 
@@ -130,10 +130,10 @@ The progression path for breaking changes is:
 ### Version Independence Clarification
 
 ```
-OpenAPI spec version:   1.0.0                          ← spec metadata, semver
-API route version:      /api/v1/                       ← structure contract version via URL path segment
-ApplicationDescription: margo.org/v1alpha1            ← structure contract version via document
-ApplicationDeployment:  application.margo.org/v1alpha1 ← structure contract version via document
+OpenAPI spec version:   1.0.0    ← spec metadata, semver
+API route version:      /api/v1/ ← structure contract version via URL path segment
+ApplicationDescription: v1alpha1 ← structure contract version via document
+ApplicationDeployment:  v1alpha1 ← structure contract version via document
 
 These are three independent versioning axes.
 A change to the API route version does NOT require a change to apiVersion.
@@ -156,7 +156,7 @@ A change to apiVersion does NOT require a change to the API route version.
     evolution and API route evolution are independent.
 
 4. **Use semver (1.0.0) for apiVersion** — Rejected in favour of Kubernetes-style API group
-   versioning (`margo.org/v1-alpha1`) which is more expressive about stability stage
+   versioning (`v1alpha1`) which is more expressive about stability stage
    (alpha/beta/stable) and is familiar to edge/cloud-native implementors.
 
 ## Related PRs

--- a/proposals/sup_apiversion_app_description_deployment.md
+++ b/proposals/sup_apiversion_app_description_deployment.md
@@ -7,27 +7,24 @@
 ## Summary
 
 Retain the `apiVersion` attribute in `ApplicationDescription` and `ApplicationDeployment`
-structures. The `apiVersion` in these structures is independent of the Margo's OpenAPI specification
-version and API route versioning — it identifies the  version of the document itself,
-following a Kubernetes-style API group versioning convention.
+structures. The `apiVersion` in these structures is independent of the Margo's OpenAPI specification — it identifies the version of the contract the document satisfies.
 
 ## Reason for proposal
 
-As API routes include version within the URL path, there is debate about the necessity of
-explicitly having an `apiVersion` attribute. However, the `apiVersion` in `ApplicationDescription`
-and `ApplicationDeployment` serves a distinct purpose — it identifies the ** version of the
-document**, not the API route version. Maintaining it provides:
+As API routes include structure contract versions within the URL path, there is debate about the necessity of
+explicitly having an `apiVersion` attribute. Since there are no URL endpoints for the `ApplicationDescription` and `ApplicationDeployment` structures, the `apiVersion` serves to identify the ** structure contract version of the
+document satisfies**, not the OpenAPI specification version. Maintaining it provides:
 
-1. Explicit  version tracking at the document level — independent of API route versioning
-2. Clear distinction between API route version (`/api/v1/`) and document  version
-3. Version available without parsing URL paths or OpenAPI spec metadata
+1. Explicit version tracking at the document level — since there is no URL endpoint to indicate the structure contract version.
+2. Clear distinction between specification version (1.0.0) and structure contract version (v1, v2, v2alpha1)
+3. The structure's contract version can be determined directly from the document since no URL is available
 4. Alignment with Kubernetes-style API group versioning conventions
-5. Enables document evolution independently of API route changes
+5. Enables document evolution independently of API and other specification changes
 6. Addresses specification [Issue #134 - margo/specification](https://github.com/margo/specification/issues/134)
 
 ## Requirements alignment acknowledgement
 
-This SUP aligns with the margo specification requirements for clear document  versioning.
+This SUP aligns with the Margo specification requirements for clear contract versioning.
 The `apiVersion` attribute in `ApplicationDescription` and `ApplicationDeployment` is explicitly
 **not** tied to:
 - The OpenAPI specification version (e.g. `1.0.0`)
@@ -43,7 +40,7 @@ It is an independent document  version identifier.
 
 | Document | apiVersion value |
 |---|---|
-| `ApplicationDescription` | `margo.org/v1-alpha1` |
+| `ApplicationDescription` | `margo.org/v1alpha1` |
 | `ApplicationDeployment` | `application.margo.org/v1alpha1` |
 
 These values are **independent** of:
@@ -68,8 +65,8 @@ ApplicationDescription:
         This is independent of the OpenAPI specification version and API route version.
         MUST be one of the Margo defined stable value.
       enum:
-        - margo.org/v1-alpha1
-      example: margo.org/v1-alpha1
+        - margo.org/v1alpha1
+      example: margo.org/v1alpha1
     kind:
       type: string
       enum: [ApplicationDescription]
@@ -111,8 +108,8 @@ The progression path for breaking changes is:
 
 | Stage | ApplicationDescription | ApplicationDeployment |
 |---|---|---|
-| Current | `margo.org/v1-alpha1` | `application.margo.org/v1alpha1` |
-| Next breaking change | `margo.org/v1-alpha2` | `application.margo.org/v1alpha2` |
+| Current | `margo.org/v1alpha1` | `application.margo.org/v1alpha1` |
+| Next breaking change | `margo.org/v1alpha2` | `application.margo.org/v1alpha2` |
 | Stable release | `margo.org/v1` | `application.margo.org/v1` |
 
 **Rules:**
@@ -124,7 +121,7 @@ The progression path for breaking changes is:
 - Both old and new `apiVersion` values SHOULD be supported simultaneously during a
   transition period of at least one major specification release
 
-> **Note:** The versioning path (e.g. `v1-alpha1` → `v1-alpha2`) is not yet fully defined.
+> **Note:** The versioning path (e.g. `v1alpha1` → `v1alpha2`) is not yet fully defined.
 > The exact criteria for what constitutes a "significantly breaking change" requiring a new
 > `apiVersion` is an open question to be resolved during SUP review.
 
@@ -134,9 +131,9 @@ The progression path for breaking changes is:
 
 ```
 OpenAPI spec version:   1.0.0                          ← spec metadata, semver
-API route version:      /api/v1/                       ← URL path segment
-ApplicationDescription: margo.org/v1-alpha1            ← document  version
-ApplicationDeployment:  application.margo.org/v1alpha1 ← document  version
+API route version:      /api/v1/                       ← structure contract version via URL path segment
+ApplicationDescription: margo.org/v1alpha1            ← structure contract version via document
+ApplicationDeployment:  application.margo.org/v1alpha1 ← structure contract version via document
 
 These are three independent versioning axes.
 A change to the API route version does NOT require a change to apiVersion.

--- a/proposals/sup_apiversion_app_description_deployment.md
+++ b/proposals/sup_apiversion_app_description_deployment.md
@@ -7,20 +7,18 @@
 ## Summary
 
 Retain the `apiVersion` attribute in `ApplicationDescription` and `ApplicationDeployment`
-structures. The `apiVersion` in these structures is independent of the Margo's OpenAPI specification — it identifies the version of the contract the document satisfies.
+structures. The `apiVersion` in these structures is independent of the Margo's OpenAPI specification — it identifies the version of the contract the document satisfies. Also need to remove `apiVersion` and `kind` attributes from all API routes of Margo's OpenAPI specification except `ApplicationDeployment` as per this SUP's rationale.
 
 ## Reason for proposal
 
 As API routes include structure contract versions within the URL path, there is debate about the necessity of
-explicitly having an `apiVersion` attribute. Since there are no URL endpoints for the `ApplicationDescription` and `ApplicationDeployment` structures, the `apiVersion` serves to identify the ** structure contract version of the
-document satisfies**, not the OpenAPI specification version. Maintaining it provides:
+explicitly having an `apiVersion` attribute. Since there is no URL endpoints for the `ApplicationDescription` apiVersion is retained. Also eventhough ApplicationDeployment has an endpoint `apiVersion` is retained because it has lifecycle outside the API scope of the API payloads and may reside either in the OCI registry or in the WFM object store, hence it needs an explicit version. 
 
 1. Explicit version tracking at the document level — since there is no URL endpoint to indicate the structure contract version.
-2. Clear distinction between specification version (1.0.0) and structure contract version (v1, v2, v2alpha1)
+2. Clear distinction between specification version (1.0.0) and structure contract version (v1, v2 etc..)
 3. The structure's contract version can be determined directly from the document since no URL is available
-4. Alignment with Kubernetes-style API group versioning conventions
-5. Enables document evolution independently of API and other specification changes
-6. Addresses specification [Issue #134 - margo/specification](https://github.com/margo/specification/issues/134)
+4. Enables document evolution independently of API and other specification changes
+5. Addresses specification [Issue #134 - margo/specification](https://github.com/margo/specification/issues/134)
 
 ## Requirements alignment acknowledgement
 
@@ -40,8 +38,8 @@ It is an independent document  version identifier.
 
 | Document | apiVersion value |
 |---|---|
-| `ApplicationDescription` | `v1alpha1` |
-| `ApplicationDeployment` | `v1alpha1` |
+| `ApplicationDescription` | `v1` |
+| `ApplicationDeployment` | `v1` |
 
 These values are **independent** of:
 - OpenAPI spec version (`1.0.0`)
@@ -65,8 +63,8 @@ ApplicationDescription:
         This is independent of the OpenAPI specification version and API route version.
         MUST be one of the Margo defined stable value.
       enum:
-        - v1alpha1
-      example: v1alpha1
+        - v1
+      example: v1
     kind:
       type: string
       enum: [ApplicationDescription]
@@ -87,12 +85,12 @@ ApplicationDeployment:
     apiVersion:
       type: string
       description: >
-         version of the ApplicationDeployment document.
+        version of the ApplicationDeployment document.
         This is independent of the OpenAPI specification version and API route version.
         MUST be one of the Margo defined stable value.
       enum:
-        - v1alpha1
-      example: v1alpha1
+        - v1
+      example: v1
     kind:
       type: string
       enum: [ApplicationDeployment]
@@ -108,9 +106,8 @@ The progression path for breaking changes is:
 
 | Stage | ApplicationDescription | ApplicationDeployment |
 |---|---|---|
-| Current | `v1alpha1` | `v1alpha1` |
-| Next breaking change | `v1alpha2` | `v1alpha2` |
-| Stable release | `v1` | `v1` |
+| Current | `v1` | `v1` |
+| Next breaking change | `v2` | `v2` |
 
 **Rules:**
 
@@ -145,10 +142,6 @@ The progression path for breaking changes is:
 - Changing error responses
 
 
-> **Note:** The versioning path (e.g. `v1alpha1` → `v1alpha2`) is not yet fully defined.
-> The exact criteria for what constitutes a "significantly breaking change" requiring a new
-> `apiVersion` is an open question to be resolved during SUP review.
-
 ---
 
 ### Version Independence Clarification
@@ -156,8 +149,8 @@ The progression path for breaking changes is:
 ```
 OpenAPI spec version:   1.0.0    ← spec metadata, semver
 API route version:      /api/v1/ ← structure contract version via URL path segment
-ApplicationDescription: v1alpha1 ← structure contract version via document
-ApplicationDeployment:  v1alpha1 ← structure contract version via document
+ApplicationDescription: v1 ← structure contract version via document
+ApplicationDeployment:  v1 ← structure contract version via document
 
 These are three independent versioning axes.
 A change to the API route version does NOT require a change to apiVersion.
@@ -180,7 +173,7 @@ A change to apiVersion does NOT require a change to the API route version.
     evolution and API route evolution are independent.
 
 4. **Use semver (1.0.0) for apiVersion** — Rejected in favour of Kubernetes-style API group
-   versioning (`v1alpha1`) which is more expressive about stability stage
+   versioning (`v1`) which is more expressive about stability stage
    (alpha/beta/stable) and is familiar to edge/cloud-native implementors.
 
 ## Related PRs

--- a/proposals/sup_apiversion_app_description_deployment.md
+++ b/proposals/sup_apiversion_app_description_deployment.md
@@ -6,66 +6,161 @@
 
 ## Summary
 
-Retain the `apiVersion` attribute in `ApplicationDescription` and `ApplicationDeployment` structures. Although API routes include the version within the URL path, keeping the apiVersion in these structures provides explicit version information and ensures consistency with semantic versioning requirements.
+Retain the `apiVersion` attribute in `ApplicationDescription` and `ApplicationDeployment`
+structures. The `apiVersion` in these structures is independent of the Margo's OpenAPI specification
+version and API route versioning — it identifies the schema version of the document itself,
+following a Kubernetes-style API group versioning convention.
 
 ## Reason for proposal
 
-As API routes include version within URL, there is debate about the necessity of explicitly having 'apiVersion' attribute for margo specified REST APIs. However, maintaining the apiVersion in ApplicationDescription and ApplicationDeployment provides:
+As API routes include version within the URL path, there is debate about the necessity of
+explicitly having an `apiVersion` attribute. However, the `apiVersion` in `ApplicationDescription`
+and `ApplicationDeployment` serves a distinct purpose — it identifies the **schema version of the
+document**, not the API route version. Maintaining it provides:
 
-1. Explicit version tracking at the application definition level
-2. Clear semantic versioning compliance
-3. Version information available without parsing URL paths
-4. Better consistency across specification structures
-5. Addresses specification issue #134
+1. Explicit schema version tracking at the document level — independent of API route versioning
+2. Clear distinction between API route version (`/api/v1/`) and document schema version
+3. Schema version available without parsing URL paths or OpenAPI spec metadata
+4. Alignment with Kubernetes-style API group versioning conventions
+5. Enables schema evolution independently of API route changes
+6. Addresses specification [Issue #134 - margo/specification](https://github.com/margo/specification/issues/134)
 
 ## Requirements alignment acknowledgement
 
-This SUP aligns with the margo specification requirements for clear API versioning and semantic versioning practices. The apiVersion attribute ensures that application descriptions and deployments carry explicit version information, improving clarity and consistency across the specification.
+This SUP aligns with the margo specification requirements for clear document schema versioning.
+The `apiVersion` attribute in `ApplicationDescription` and `ApplicationDeployment` is explicitly
+**not** tied to:
+- The OpenAPI specification version (e.g. `1.0.0`)
+- The API route version (e.g. `/api/v1/`)
+
+It is an independent document schema version identifier.
 
 **Related Feature(s):** [Issue #134 - margo/specification](https://github.com/margo/specification/issues/134)
 
 ## Technical proposal
 
+### apiVersion Values
+
+| Document | apiVersion value |
+|---|---|
+| `ApplicationDescription` | `margo.org/v1-alpha1` |
+| `ApplicationDeployment` | `application.margo.org/v1alpha1` |
+
+These values are **independent** of:
+- OpenAPI spec version (`1.0.0`)
+- API route version (`/api/v1/`)
+
+---
+
 ### Changes to ApplicationDescription
 
-Retain the `apiVersion` field in the `ApplicationDescription` schema:
+Retain the `apiVersion` field in the `ApplicationDescription` schema with the correct value:
 
 ```yaml
 ApplicationDescription:
   type: object
+  required: [apiVersion, kind]
   properties:
     apiVersion:
       type: string
-      description: Semantic version of the application API specification
-      example: "1.0.0"
+      description: >
+        Schema version of the ApplicationDescription document.
+        This is independent of the OpenAPI specification version and API route version.
+        MUST be one of the Margo defined stable value.
+      enum:
+        - margo.org/v1-alpha1
+      example: margo.org/v1-alpha1
+    kind:
+      type: string
+      enum: [ApplicationDescription]
     # ... other properties
 ```
 
+---
+
 ### Changes to ApplicationDeployment
 
-Retain the `apiVersion` field in the `ApplicationDeployment` schema:
+Retain the `apiVersion` field in the `ApplicationDeployment` schema with the correct value:
 
 ```yaml
 ApplicationDeployment:
   type: object
+  required: [apiVersion, kind]
   properties:
     apiVersion:
       type: string
-      description: Semantic version of the application API specification
-      example: "1.0.0"
+      description: >
+        Schema version of the ApplicationDeployment document.
+        This is independent of the OpenAPI specification version and API route version.
+        MUST be one of the Margo defined stable value.
+      enum:
+        - application.margo.org/v1alpha1
+      example: application.margo.org/v1alpha1
+    kind:
+      type: string
+      enum: [ApplicationDeployment]
     # ... other properties
 ```
 
-### Version Consistency
+---
 
-- The `apiVersion` value must match the OpenAPI specification version
-- Must follow semantic versioning format (MAJOR.MINOR.PATCH)
-- Should be maintained in sync with API route versioning
+### Version Progression
+
+The `apiVersion` follows a Kubernetes-style API group versioning convention.
+The progression path for breaking changes is:
+
+| Stage | ApplicationDescription | ApplicationDeployment |
+|---|---|---|
+| Current | `margo.org/v1-alpha1` | `application.margo.org/v1alpha1` |
+| Next breaking change | `margo.org/v1-alpha2` | `application.margo.org/v1alpha2` |
+| Stable release | `margo.org/v1` | `application.margo.org/v1` |
+
+**Rules:**
+
+- A new `apiVersion` value MUST be introduced for any **significantly breaking** schema change
+- Non-breaking additive changes (new optional fields) MAY be made within the same `apiVersion`
+- Clients MUST reject documents with an unrecognised `apiVersion`
+- Servers MUST NOT serve documents with a deprecated `apiVersion` after its removal date
+- Both old and new `apiVersion` values SHOULD be supported simultaneously during a
+  transition period of at least one major specification release
+
+> **Note:** The versioning path (e.g. `v1-alpha1` → `v1-alpha2`) is not yet fully defined.
+> The exact criteria for what constitutes a "significantly breaking change" requiring a new
+> `apiVersion` is an open question to be resolved during SUP review.
+
+---
+
+### Version Independence Clarification
+
+```
+OpenAPI spec version:   1.0.0                          ← spec metadata, semver
+API route version:      /api/v1/                       ← URL path segment
+ApplicationDescription: margo.org/v1-alpha1            ← document schema version
+ApplicationDeployment:  application.margo.org/v1alpha1 ← document schema version
+
+These are three independent versioning axes.
+A change to the API route version does NOT require a change to apiVersion.
+A change to apiVersion does NOT require a change to the API route version.
+```
+
+---
 
 ## Alternatives considered
 
-1. **Remove apiVersion entirely** - Rejected because it removes explicit version information from application definitions (application description) and application deployment manifest, making it harder to track versioning at the application description/deployment manifests. Remove apiVersion from the body of the API requests as it is part of the API route, keep the apiVersion in ApplicationDescription (and ApplicationDeployment)
+1. **Remove apiVersion entirely** — Rejected because it removes explicit schema version
+   information from document definitions, making it impossible for consumers to determine
+   which schema version a document conforms to without out-of-band information.
 
+2. **Tie apiVersion to OpenAPI spec version (1.0.0)** — Rejected because the document schema
+   version and the API specification version are independent concerns. Coupling them would
+   force unnecessary document version bumps on unrelated API changes.
+
+3. **Tie apiVersion to API route version (/api/v1/)** — Rejected for the same reason — document
+   schema evolution and API route evolution are independent.
+
+4. **Use semver (1.0.0) for apiVersion** — Rejected in favour of Kubernetes-style API group
+   versioning (`margo.org/v1-alpha1`) which is more expressive about stability stage
+   (alpha/beta/stable) and is familiar to edge/cloud-native implementors.
 
 ## Related PRs
 

--- a/proposals/sup_apiversion_app_description_deployment.md
+++ b/proposals/sup_apiversion_app_description_deployment.md
@@ -8,32 +8,32 @@
 
 Retain the `apiVersion` attribute in `ApplicationDescription` and `ApplicationDeployment`
 structures. The `apiVersion` in these structures is independent of the Margo's OpenAPI specification
-version and API route versioning — it identifies the schema version of the document itself,
+version and API route versioning — it identifies the  version of the document itself,
 following a Kubernetes-style API group versioning convention.
 
 ## Reason for proposal
 
 As API routes include version within the URL path, there is debate about the necessity of
 explicitly having an `apiVersion` attribute. However, the `apiVersion` in `ApplicationDescription`
-and `ApplicationDeployment` serves a distinct purpose — it identifies the **schema version of the
+and `ApplicationDeployment` serves a distinct purpose — it identifies the ** version of the
 document**, not the API route version. Maintaining it provides:
 
-1. Explicit schema version tracking at the document level — independent of API route versioning
-2. Clear distinction between API route version (`/api/v1/`) and document schema version
-3. Schema version available without parsing URL paths or OpenAPI spec metadata
+1. Explicit  version tracking at the document level — independent of API route versioning
+2. Clear distinction between API route version (`/api/v1/`) and document  version
+3. Version available without parsing URL paths or OpenAPI spec metadata
 4. Alignment with Kubernetes-style API group versioning conventions
-5. Enables schema evolution independently of API route changes
+5. Enables document evolution independently of API route changes
 6. Addresses specification [Issue #134 - margo/specification](https://github.com/margo/specification/issues/134)
 
 ## Requirements alignment acknowledgement
 
-This SUP aligns with the margo specification requirements for clear document schema versioning.
+This SUP aligns with the margo specification requirements for clear document  versioning.
 The `apiVersion` attribute in `ApplicationDescription` and `ApplicationDeployment` is explicitly
 **not** tied to:
 - The OpenAPI specification version (e.g. `1.0.0`)
 - The API route version (e.g. `/api/v1/`)
 
-It is an independent document schema version identifier.
+It is an independent document  version identifier.
 
 **Related Feature(s):** [Issue #134 - margo/specification](https://github.com/margo/specification/issues/134)
 
@@ -54,7 +54,7 @@ These values are **independent** of:
 
 ### Changes to ApplicationDescription
 
-Retain the `apiVersion` field in the `ApplicationDescription` schema with the correct value:
+Retain the `apiVersion` field in the `ApplicationDescription`  with the correct value:
 
 ```yaml
 ApplicationDescription:
@@ -64,7 +64,7 @@ ApplicationDescription:
     apiVersion:
       type: string
       description: >
-        Schema version of the ApplicationDescription document.
+         version of the ApplicationDescription document.
         This is independent of the OpenAPI specification version and API route version.
         MUST be one of the Margo defined stable value.
       enum:
@@ -80,7 +80,7 @@ ApplicationDescription:
 
 ### Changes to ApplicationDeployment
 
-Retain the `apiVersion` field in the `ApplicationDeployment` schema with the correct value:
+Retain the `apiVersion` field in the `ApplicationDeployment`  with the correct value:
 
 ```yaml
 ApplicationDeployment:
@@ -90,7 +90,7 @@ ApplicationDeployment:
     apiVersion:
       type: string
       description: >
-        Schema version of the ApplicationDeployment document.
+         version of the ApplicationDeployment document.
         This is independent of the OpenAPI specification version and API route version.
         MUST be one of the Margo defined stable value.
       enum:
@@ -117,7 +117,7 @@ The progression path for breaking changes is:
 
 **Rules:**
 
-- A new `apiVersion` value MUST be introduced for any **significantly breaking** schema change
+- A new `apiVersion` value MUST be introduced for any **significantly breaking**  change
 - Non-breaking additive changes (new optional fields) MAY be made within the same `apiVersion`
 - Clients MUST reject documents with an unrecognised `apiVersion`
 - Servers MUST NOT serve documents with a deprecated `apiVersion` after its removal date
@@ -135,8 +135,8 @@ The progression path for breaking changes is:
 ```
 OpenAPI spec version:   1.0.0                          ← spec metadata, semver
 API route version:      /api/v1/                       ← URL path segment
-ApplicationDescription: margo.org/v1-alpha1            ← document schema version
-ApplicationDeployment:  application.margo.org/v1alpha1 ← document schema version
+ApplicationDescription: margo.org/v1-alpha1            ← document  version
+ApplicationDeployment:  application.margo.org/v1alpha1 ← document  version
 
 These are three independent versioning axes.
 A change to the API route version does NOT require a change to apiVersion.
@@ -147,16 +147,16 @@ A change to apiVersion does NOT require a change to the API route version.
 
 ## Alternatives considered
 
-1. **Remove apiVersion entirely** — Rejected because it removes explicit schema version
+1. **Remove apiVersion entirely** — Rejected because it removes explicit  version
    information from document definitions, making it impossible for consumers to determine
-   which schema version a document conforms to without out-of-band information.
+   which  version a document conforms to without out-of-band information.
 
-2. **Tie apiVersion to OpenAPI spec version (1.0.0)** — Rejected because the document schema
+2. **Tie apiVersion to OpenAPI spec version (1.0.0)** — Rejected because the document 
    version and the API specification version are independent concerns. Coupling them would
    force unnecessary document version bumps on unrelated API changes.
 
 3. **Tie apiVersion to API route version (/api/v1/)** — Rejected for the same reason — document
-   schema evolution and API route evolution are independent.
+    evolution and API route evolution are independent.
 
 4. **Use semver (1.0.0) for apiVersion** — Rejected in favour of Kubernetes-style API group
    versioning (`margo.org/v1-alpha1`) which is more expressive about stability stage

--- a/proposals/sup_apiversion_app_description_deployment.md
+++ b/proposals/sup_apiversion_app_description_deployment.md
@@ -121,6 +121,30 @@ The progression path for breaking changes is:
 - Both old and new `apiVersion` values SHOULD be supported simultaneously during a
   transition period of at least one major specification release
 
+#### Breaking changes:
+- Renaming an endpoint, properties/fields, enumeration value, or parameter
+- Removing an endpoint, properties/fields, enumeration value, or parameter
+- Changing data types or expected format
+- Making optional things required
+- Changing the semantics or behavior of an endpoint
+- Changing HTTP method or response codes
+- Making any validations stricter
+- Changing authentication/authorization rules
+
+#### Non-Breaking changes:
+- Adding new endpoints, properties/fields, or parameters
+- Adding optional parameters
+- Adding headers
+- Adding metadata
+- Fixing incorrect behaviors (bugs)
+
+#### Gray areas - can be breaking if not handled well:
+- Adding enumeration values
+- Changing defaults
+- Reordering fields
+- Changing error responses
+
+
 > **Note:** The versioning path (e.g. `v1alpha1` → `v1alpha2`) is not yet fully defined.
 > The exact criteria for what constitutes a "significantly breaking change" requiring a new
 > `apiVersion` is an open question to be resolved during SUP review.


### PR DESCRIPTION
Margo's OpenAPIs have apiversion information explicitly embedded within each API manifest. It is not required as version information can be found from API path itself. So this SUP will remove apiversion and kind fields from all API manifests. And retain apiVersion attribute and remove kind attribute in ApplicationDescription