### PR TITLE
[DRAFT] bisects DeviceCapabilityManifest into different documents

### DIFF
--- a/proposals/sup_bisect_device_manifest.md
+++ b/proposals/sup_bisect_device_manifest.md
@@ -54,13 +54,15 @@ Identity data rarel changes. Resource related data changes often. Sending them t
 * No independent updates: You cannot version or evolve identity fields and resource fields separately.
 
 ### Problem 2: Limited descriptions for hardware and networks
-The current setup uses basic labels that cannot share real-world details.
+The current setup uses basic labels that cannot share real-world details, as of now:
 
-* A graphics card (GPU) can only list its type and manufacturer. It cannot show its VRAM size, system path, or architecture.
-* A network connection (like CAN Bus) can only list its type. It cannot show its speed, protocol, or channel ID.
+* A graphics card (GPU) lists only type and manufacturer. It doesn't show its VRAM size, system path, or architecture etc.
+* A network connection (like CAN Bus) has only a type field. It doesn't show its speed, protocol, or channel ID etc.
+
+The point to make here is that there would be requirement for a much complexer data structure for different resources and capabilities provided by platforms. It would be better to detach give them their dedicated documents.
 
 ### Problem 3: Basic computing fields cannot grow
-Standard fields like cpu, memory, and storage are treated as rigid, flat text blocks. You cannot expand their rules. They need to become standalone profile files with their own flexible rulebooks.
+Standard fields like cpu, memory, and storage are treated as rigid, flat text blocks. You cannot expand their structure easily. They need to become standalone profile files with their own flexible rulebooks.
 
 ### Problem 4: Hardware types are hardcoded
 Adding a new piece of hardware (like an AI accelerator or secure chip) forces a complete update to the core system specification. This creates a bottleneck. Device makers cannot launch new features until the main community updates the global rules.

--- a/proposals/sup_bisect_device_manifest.md
+++ b/proposals/sup_bisect_device_manifest.md
@@ -3,6 +3,7 @@
 **Status:** Draft  
 **Owner:** @singhmj-1  
 **Depends on:** `sup_device_roles_to_capabilities`
+
 **Note:** This SUP has been extracted from [Resource Discovery and Conflict Resolution](https://github.com/margo/specification-enhancements/pull/66) SUP, as that one has become too complex.
 
 ---
@@ -12,15 +13,16 @@
 The `sup_device_roles_to_capabilities` SUP removed `roles` and promoted all device fields to the `properties` root. The resulting `DeviceCapabilitiesManifest` still conflates two distinct concerns:
 
 - **Device identity** — `id`, `vendor`, `modelNumber`, `serialNumber`. Static after onboarding. Never changes.
-- **Device capabilities** — `cpu`, `memory`, `storage`, `otelCollector`, `supportedRuntimes`, `supportedDeploymentTypes`, `peripherals`, `interfaces`. Dynamic — updated as hardware and runtime state changes.
+- **Device profile information** — `cpu`, `memory`, `storage`, `otelCollector`, `supportedRuntimes`, `supportedDeploymentTypes`, `peripherals`, `interfaces`. Changes primarily when hardware is added/removed or runtime support is modified.
 
 This proposal:
 
-1. Bisects the document into two separate documents with separate endpoints: **DeviceManifest** (identity only) and individual **CapabilityState** documents (one per capability).
-2. Expands the definition of a capability.
+1. Bisects the document into two separate documents with separate endpoints: **DeviceManifest** (identity only) and individual **ProfileState** documents (one per device profile attribute).
+2. Introduces the concept of **Device Profile** — a structured description of all hardware resources, interfaces, peripherals, and services available on a device.
 3. Removes the flat `peripherals` and `interfaces` enumerations entirely.
-4. Promotes all capability data — including base compute fields — into structured `CapabilityState` documents, each posted individually to the capabilities endpoint.
-5. Introduces the `CapabilityState` model inline, as the Capability Definition Framework SUP has not yet been formally introduced.
+4. Promotes all profile data — including base compute fields and services — into structured `ProfileState` documents, each posted individually to the profile endpoint.
+5. Simplifies the `ProfileState` schema to remove unnecessary wrapper fields.
+6. Provides formal schema specifications for each standard profile URI.
 
 ---
 
@@ -53,12 +55,12 @@ This proposal modifies the schema produced by `sup_device_roles_to_capabilities`
 
 ## Reason for Proposal
 
-### Problem 1 — Identity and capabilities are coupled in a single document
+### Problem 1 — Identity and profile information are coupled in a single document
 
-Identity fields (`id`, `vendor`, `modelNumber`, `serialNumber`) never change after onboarding. Capability fields change frequently — whenever workloads are deployed, hardware is added, or runtime configuration changes. Sending both together means:
+Identity fields (`id`, `vendor`, `modelNumber`, `serialNumber`) never change after onboarding. Profile fields change infrequently — only when hardware is added/removed or when runtime support is modified. Sending both together means:
 
-- A capability update forces re-sending identity data that has not changed
-- The WFM cannot distinguish a capability update from an identity change
+- A profile update forces re-sending identity data that has not changed
+- The WFM cannot distinguish an identity change from a profile change
 - The two concerns cannot evolve or be versioned independently
 
 ### Problem 2 — `peripherals` and `interfaces` use closed enumerations that cannot express structured state
@@ -77,38 +79,44 @@ Cannot express VRAM, device path, allocation state, or compute architecture. A C
 
 Cannot express baud rate, protocol, channel identity, or allocation state.
 
-### Problem 3 — Base compute fields are not capabilities in the structured sense
+### Problem 3 — Base compute fields lack a structured model for extension
 
-Fields like `cpu`, `memory`, `storage`, `otelCollector`, `supportedRuntimes`, and `supportedDeploymentTypes` are currently special-cased flat/scalar fields. There is no mechanism to extend their schema, express allocation state, or update them independently of each other. Treating them as first-class `CapabilityState` entries resolves this.
+Fields like `cpu`, `memory`, `storage`, `otelCollector`, `supportedRuntimes`, and `supportedDeploymentTypes` are currently special-cased flat/scalar fields. There is no mechanism to extend their schema, express allocation metadata, or document their update semantics. Treating them as first-class `ProfileState` entries with formal schema specifications resolves this.
 
 ---
 
-## Expanding the Definition of Capability
+## Introducing Device Profile
 
-So far, the definition of a capability is restrictive, but this framework expands it:
+This proposal introduces the concept of a **Device Profile** — a comprehensive description of all hardware resources, communication interfaces, physical peripherals, and platform services available on a device.
 
-> A capability represents wide variety of **platform-managed concerns** 
-including the following:
-> * "Hardware resources" such as GPUs, cameras, fieldbus channels etc.
-> * "Software capabilities" such as persistent storage, pre-installed 
-runtimes etc.
-> * "Platform services" such as api gateways, security vaults, otel collectors 
-endpoints, pki, message buses etc.
+A **Device Profile** encompasses:
 
+- **Resources** (CPU, Memory, Storage) — Quantifiable hardware resources
+- **Interfaces** (Ethernet, WiFi, CAN Bus, USB) — Communication and connectivity mechanisms
+- **Peripherals** (GPU, Camera, Microphone) — Specialized hardware components
+- **Services** (Secret Vault, DNS Server, OTeL Collector) — Platform-managed services
+- **Capabilities** (Video encoding, AI acceleration, observability collection) — Functional abilities enabled by hardware, services, or software
 
-### Capability Model
-The current spec treats a "capability" as a flat enumeration value — a GPU is `{ "type": "gpu" }`, an interface is `{ "type": "ethernet" }`. This model cannot express runtime state, allocation, or structured metadata.
+### Key Insight: Things vs. Capabilities
 
-This proposal introduces a richer capability model. A **CapabilityState** is a structured document that:
+A crucial distinction: not all profile attributes are themselves *capabilities*. Rather, they are platform-managed *resources* and *services* that collectively form the device's profile and enable certain capabilities:
 
-- References a **capability URI** — a globally unique identifier for the capability type (e.g. `capability.margo.org/hardware/gpu`)
-- Carries a **spec** — a capability-specific object whose schema is defined by the capability type
+- A **GPU** (peripheral) is not a capability, but it *enables* video encoding and AI acceleration (capabilities)
+- A **Secret Vault** (service) is not a capability, but it *enables* secure credential management (capability)
+- A **DNS Server** (service) is not a capability, but it *enables* IP address assignment (capability)
+- An **Ethernet interface** (interface) is not a capability, but it *enables* network communication (capability)
 
-The capability URI is the key. It identifies not just the type of capability, but the schema that governs the `spec` content. This allows:
+By treating all of these under the unified **Device Profile** concept, we can describe the complete environment available to workloads without conflating the *providers* of capabilities with the *capabilities* themselves.
 
-- Vendors to define their own capability types under their own URI namespace (e.g. `capability.acme.com/fieldbus/profinet`)
-- The WFM to validate `spec` content against the schema for the referenced URI
-- Capabilities to be updated, added, or removed independently — one `CapabilityState` per capability, one request per update
+### Pattern Extensibility
+
+This Device Profile pattern is designed to be reusable beyond devices. Similar profiles could be defined for:
+
+- **Workload Profile** — describing workload requirements and constraints
+- **Workflow Profile** — describing workflow execution environment needs
+- **Gateway Profile** — describing gateway-specific resources and services
+
+This creates a consistent mental model across the Margo ecosystem.
 
 ---
 
@@ -124,15 +132,25 @@ POST   /api/v1/clients/{clientId}/devices/{deviceId}
 PUT    /api/v1/clients/{clientId}/devices/{deviceId}
 DELETE /api/v1/clients/{clientId}/devices/{deviceId}
 
-# Individual capability states
-POST   /api/v1/clients/{clientId}/devices/{deviceId}/capabilities
-PUT    /api/v1/clients/{clientId}/devices/{deviceId}/capabilities
-DELETE /api/v1/clients/{clientId}/devices/{deviceId}/capabilities
+# Device profile state
+POST   /api/v1/clients/{clientId}/devices/{deviceId}/profile
+PUT    /api/v1/clients/{clientId}/devices/{deviceId}/profile
+DELETE /api/v1/clients/{clientId}/devices/{deviceId}/profile
 ```
 
-**Ordering requirement:** `DeviceManifest` MUST be registered before any `CapabilityState` can be submitted for the same `deviceId`. If the WFM receives a `CapabilityState` for an unknown `deviceId`, it MUST reject with `404 Not Found`.
+**Ordering requirement:** `DeviceManifest` MUST be registered before any `ProfileState` can be submitted for the same `deviceId`. If the WFM receives a `ProfileState` for an unknown `deviceId`, it MUST reject with `404 Not Found`.
 
-**Individual updates:** Each POST or PUT to the capabilities endpoint carries exactly one `CapabilityState` document. The WFM uses `metadata.id` to identify which capability is being created or updated. Multiple capabilities are registered by sending multiple requests.
+**Update granularity:**
+- **Individual updates (default):** Each POST or PUT to the profile endpoint carries exactly one `ProfileState` document. The WFM uses `id` to identify which profile attribute is being created or updated. Multiple attributes are registered by sending multiple requests.
+- **Bulk updates (optional):** Alternatively, clients MAY submit an array of `ProfileState` documents in a single request to reduce chattiness during initial onboarding:
+  ```json
+  [
+    { "id": "deviceprofile.margo.org/resource/cpu", "spec": { ... } },
+    { "id": "deviceprofile.margo.org/resource/memory", "spec": { ... } },
+    { "id": "deviceprofile.margo.org/peripherals/gpu", "spec": { ... } }
+  ]
+  ```
+  The WFM processes all items atomically: either all succeed or all fail.
 
 **Gateway hierarchy:** The `{deviceId}` path hierarchy encoding (e.g. `gateway1/deviceA`) is retained unchanged on both endpoint groups.
 
@@ -148,7 +166,7 @@ DELETE /api/v1/clients/{clientId}/devices/{deviceId}/capabilities
 | `400 Bad Request` | Missing or invalid `content-digest` header, or malformed request body. |
 | `401 Unauthorized` | Signature verification failed. |
 | `403 Forbidden` | Client certificate is not trusted or has been revoked. |
-| `404 Not Found` | No client with the given `clientId` found, or no `DeviceManifest` registered for the given `deviceId` (capabilities endpoint only). |
+| `404 Not Found` | No client with the given `clientId` found, or no `DeviceManifest` registered for the given `deviceId` (profile endpoint only). |
 | `422 Unprocessable Content` | Request body includes a semantic error. |
 
 ---
@@ -163,14 +181,10 @@ Carries device identity only. Sent once at onboarding. Updated only if identity 
 
 ```json
 {
-  "apiVersion": "margo.org/v1",
-  "kind": "DeviceManifest",
-  "properties": {
-    "id": "northstarida.xtapro.k8s.edge",
-    "vendor": "Northstar Industrial Devices",
-    "modelNumber": "332ANZE1-N1",
-    "serialNumber": "PF45343-AA"
-  }
+  "id": "northstarida.xtapro.k8s.edge",
+  "vendor": "Northstar Industrial Devices",
+  "modelNumber": "332ANZE1-N1",
+  "serialNumber": "PF45343-AA"
 }
 ```
 
@@ -178,34 +192,28 @@ Carries device identity only. Sent once at onboarding. Updated only if identity 
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `apiVersion` | string | Y | Must be `margo.org/v1`. |
-| `kind` | string | Y | Must be `DeviceManifest`. |
-| `properties.id` | string | Y | Unique device identifier. Must include only unreserved characters as specified in RFC3986 plus the path separator `/`. |
-| `properties.vendor` | string | Y | Device vendor name. |
-| `properties.modelNumber` | string | Y | Device model number. |
-| `properties.serialNumber` | string | Y | Device serial number. |
+| `id` | string | Y | Unique device identifier. Must include only unreserved characters as specified in RFC3986 plus the path separator `/`. |
+| `vendor` | string | Y | Device vendor name. |
+| `modelNumber` | string | Y | Device model number. |
+| `serialNumber` | string | Y | Device serial number. |
 
 ---
 
-### CapabilityState
+### ProfileState
 
-Each capability is submitted as an individual `CapabilityState` document. There is no wrapping manifest — the `CapabilityState` is the document.
+Each device profile attribute is submitted as an individual `ProfileState` document.
 
-**Endpoint:** `POST /api/v1/clients/{clientId}/devices/{deviceId}/capabilities`
+**Endpoint:** `POST /api/v1/clients/{clientId}/devices/{deviceId}/profile`
 
-The WFM uses `metadata.id` to identify which capability is being registered or updated. Submitting a `CapabilityState` for a `capability` URI that already exists for the device replaces the previous state.
+The WFM uses `id` to identify which profile attribute is being registered or updated. Submitting a `ProfileState` for a profile URI that already exists for the device replaces the previous state.
 
 **Document structure:**
 
 ```json
 {
-  "apiVersion": "margo.org/v1",
-  "kind": "CapabilityState",
-  "metadata": {
-    "id": "<capability-uri>"
-  },
+  "id": "<profile-uri>",
   "spec": {
-    // capability-specific state object
+    // profile-specific state object
   }
 }
 ```
@@ -214,127 +222,244 @@ The WFM uses `metadata.id` to identify which capability is being registered or u
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `apiVersion` | string | Y | Must be `margo.org/v1`. |
-| `kind` | string | Y | Must be `CapabilityState`. |
-| `metadata.id` | string | Y | URI identifying the capability type. Determines the schema of `spec`. |
-| `spec` | object | Y | Runtime state for this capability. Content is governed by the schema for the referenced capability URI. |
+| `id` | string | Y | URI identifying the profile attribute type. Determines the schema of `spec`. |
+| `spec` | object | Y | State information for this profile attribute. Content is governed by the schema for the referenced profile URI. |
 
-**DELETE — removing a capability:**
+**DELETE — removing a profile attribute:**
 
-To remove a capability from a device (e.g. hardware was physically removed), send a DELETE request with the capability URI in the request body:
+To remove a profile attribute from a device (e.g. hardware was physically removed), send a DELETE request with the profile URI in the request body:
 
 ```
-DELETE /api/v1/clients/{clientId}/devices/{deviceId}/capabilities
+DELETE /api/v1/clients/{clientId}/devices/{deviceId}/profile
 ```
 
 ```json
 {
-  "id": "capability.margo.org/hardware/gpu"
+  "id": "deviceprofile.margo.org/peripherals/gpu"
 }
 ```
 
-The WFM MUST remove the stored `CapabilityState` for the given `capability` URI on the given device.
+The WFM MUST remove the stored `ProfileState` for the given profile URI against the given device.
 
 ---
 
-### Capability URI Namespace
+### Profile URI Namespace
 
-Capability URIs follow a reverse-DNS convention:
+Profile URIs follow a reverse-DNS convention and include a category prefix indicating the type of profile information:
 
-| Namespace | Owner | Example |
-|-----------|-------|---------|
-| `capability.margo.org/*` | Margo specification — standardised capabilities | `capability.margo.org/hardware/gpu` |
-| `capability.<vendor-domain>/*` | Vendor-defined capabilities | `capability.acme.com/fieldbus/profinet` |
+| Namespace | Category | Owner | Example |
+|-----------|----------|-------|---------|
+| `deviceprofile.margo.org/resource/*` | Hardware resources | Margo specification | `deviceprofile.margo.org/resource/cpu` |
+| `deviceprofile.margo.org/interface/*` | Communication interfaces | Margo specification | `deviceprofile.margo.org/interface/ethernet` |
+| `deviceprofile.margo.org/peripherals/*` | Peripheral hardware | Margo specification | `deviceprofile.margo.org/peripherals/gpu` |
+| `deviceprofile.margo.org/service/*` | Platform services | Margo specification | `deviceprofile.margo.org/service/vault` |
+| `deviceprofile.margo.org/capability/*` | Functional capabilities | Margo specification | `deviceprofile.margo.org/capability/video-encoding` |
+| `deviceprofile.<vendor-domain>/*` | Vendor-defined profile attributes | Vendor | `deviceprofile.acme.com/fieldbus/profinet` |
 
-The WFM MUST accept any well-formed URI in `metadata.id`. It MUST validate `spec` content against the schema for the referenced URI if a schema is registered. If no schema is registered for the URI, the WFM MUST store the `spec` as-is without validation.
+The WFM MUST accept any well-formed URI in `id`. It MUST validate `spec` content against the schema for the referenced URI if a schema is registered. If no schema is registered for the URI, the WFM MUST report a rejection.
 
 ---
 
-### Standard Capability URIs Introduced by This SUP
+### Standard Profile URIs Introduced by This SUP
 
-The following capability URIs replace the flat fields from the baseline schema. All are under the `capability.margo.org` namespace.
+The following profile URIs replace the flat fields from the baseline schema. All are under the `deviceprofile.margo.org` namespace. Each includes a formal schema specification.
 
-#### `capability.margo.org/compute/cpu`
+#### `deviceprofile.margo.org/resource/cpu`
 
-Replaces the `cpu` array field.
+Replaces the `cpu` array field. Describes the total CPU capacity of the device (does not change unless physical hardware is replaced).
+
+**Schema:**
 
 ```json
 {
-  "apiVersion": "margo.org/v1",
-  "kind": "CapabilityState",
-  "metadata": {
-    "id": "capability.margo.org/compute/cpu"
-  },
+  "id": "deviceprofile.margo.org/resource/cpu",
+  "spec": {
+    "type": "object",
+    "required": ["cpus"],
+    "properties": {
+      "cpus": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "required": ["cores", "architecture"],
+          "properties": {
+            "cores": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of CPU cores"
+            },
+            "architecture": {
+              "type": "string",
+              "enum": ["amd64", "arm64", "arm", "x86"],
+              "description": "CPU architecture"
+            },
+            "model": {
+              "type": "string",
+              "description": "Optional CPU model name"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Example:**
+
+```json
+{
+  "id": "deviceprofile.margo.org/resource/cpu",
   "spec": {
     "cpus": [
-      { "cores": 24, "architecture": "amd64" }
+      { "cores": 24, "architecture": "amd64", "model": "Intel Xeon" }
     ]
   }
 }
 ```
 
-#### `capability.margo.org/compute/memory`
+---
 
-Replaces the `memory` field.
+#### `deviceprofile.margo.org/resource/memory`
+
+Replaces the `memory` field. Describes the total system memory capacity (does not change unless physical memory is upgraded).
+
+**Schema:**
 
 ```json
 {
-  "apiVersion": "margo.org/v1",
-  "kind": "CapabilityState",
-  "metadata": {
-    "id": "capability.margo.org/compute/memory"
-  },
+  "id": "deviceprofile.margo.org/resource/memory",
+  "spec": {
+    "type": "object",
+    "required": ["available"],
+    "properties": {
+      "available": {
+        "type": "string",
+        "pattern": "^\\d+\\s*(Gi|Mi|Ki|G|M|K)$",
+        "description": "Total memory in binary units (Gi, Mi, etc.) or SI units (G, M, etc.)"
+      }
+    }
+  }
+}
+```
+
+**Example:**
+
+```json
+{
+  "id": "deviceprofile.margo.org/resource/memory",
   "spec": {
     "available": "59 Gi"
   }
 }
 ```
 
-#### `capability.margo.org/compute/storage`
+---
 
-Replaces the `storage` field.
+#### `deviceprofile.margo.org/resource/storage`
+
+Replaces the `storage` field. Describes the total persistent storage capacity (does not change unless physical storage is upgraded).
+
+**Schema:**
 
 ```json
 {
-  "apiVersion": "margo.org/v1",
-  "kind": "CapabilityState",
-  "metadata": {
-    "id": "capability.margo.org/compute/storage"
-  },
+  "id": "deviceprofile.margo.org/resource/storage",
+  "spec": {
+    "type": "object",
+    "required": ["available"],
+    "properties": {
+      "available": {
+        "type": "string",
+        "pattern": "^\\d+\\s*(Gi|Mi|Ki|G|M|K)$",
+        "description": "Total storage in binary units (Gi, Mi, etc.) or SI units (G, M, etc.)"
+      }
+    }
+  }
+}
+```
+
+**Example:**
+
+```json
+{
+  "id": "deviceprofile.margo.org/resource/storage",
   "spec": {
     "available": "1862 Gi"
   }
 }
 ```
 
-#### `capability.margo.org/service/otel-collector`
+---
 
-Replaces the `otelCollector` boolean field.
+#### `deviceprofile.margo.org/service/otel-collector`
+
+Replaces the `otelCollector` boolean field. Indicates whether the device has OTeL collection enabled.
+
+**Schema:**
 
 ```json
 {
-  "apiVersion": "margo.org/v1",
-  "kind": "CapabilityState",
-  "metadata": {
-    "id": "capability.margo.org/service/otel-collector"
-  },
+  "id": "deviceprofile.margo.org/service/otel-collector",
+  "spec": {
+    "type": "object",
+    "required": ["present"],
+    "properties": {
+      "present": {
+        "type": "boolean",
+        "description": "Whether OTeL collection is enabled on this device"
+      }
+    }
+  }
+}
+```
+
+**Example:**
+
+```json
+{
+  "id": "deviceprofile.margo.org/service/otel-collector",
   "spec": {
     "present": true
   }
 }
 ```
 
-#### `capability.margo.org/runtime/supported`
+---
 
-Replaces the `supportedRuntimes` and `supportedDeploymentTypes` fields.
+#### `deviceprofile.margo.org/capability/runtimes`
+
+Replaces the `supportedRuntimes` and `supportedDeploymentTypes` fields. Describes the runtime environments and deployment mechanisms supported by the device.
+
+**Schema:**
 
 ```json
 {
-  "apiVersion": "margo.org/v1",
-  "kind": "CapabilityState",
-  "metadata": {
-    "id": "capability.margo.org/runtime/supported"
-  },
+  "id": "deviceprofile.margo.org/capability/runtimes",
+  "spec": {
+    "type": "object",
+    "properties": {
+      "runtimes": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "List of supported container/runtime standards (e.g., 'oci', 'wasm')"
+      },
+      "deploymentTypes": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "List of supported deployment mechanisms (e.g., 'helm', 'compose', 'bare')"
+      }
+    }
+  }
+}
+```
+
+**Example:**
+
+```json
+{
+  "id": "deviceprofile.margo.org/capability/runtimes",
   "spec": {
     "runtimes": ["oci"],
     "deploymentTypes": ["helm", "compose"]
@@ -342,17 +467,62 @@ Replaces the `supportedRuntimes` and `supportedDeploymentTypes` fields.
 }
 ```
 
-#### `capability.margo.org/hardware/gpu`
+---
 
-Replaces `peripherals` entries of type `gpu`.
+#### `deviceprofile.margo.org/peripherals/gpu`
+
+Replaces `peripherals` entries of type `gpu`. Describes GPU hardware available on the device, including allocation state for orchestration.
+
+**Schema:**
 
 ```json
 {
-  "apiVersion": "margo.org/v1",
-  "kind": "CapabilityState",
-  "metadata": {
-    "id": "capability.margo.org/hardware/gpu"
-  },
+  "id": "deviceprofile.margo.org/peripherals/gpu",
+  "spec": {
+    "type": "object",
+    "required": ["gpus"],
+    "properties": {
+      "gpus": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "required": ["devicePath", "model"],
+          "properties": {
+            "devicePath": {
+              "type": "string",
+              "description": "Device path (e.g., '/dev/nvidia0')"
+            },
+            "model": {
+              "type": "string",
+              "description": "GPU model name (e.g., 'NVIDIA A100')"
+            },
+            "architecture": {
+              "type": "string",
+              "description": "GPU architecture (e.g., 'ampere', 'hopper')"
+            },
+            "vramGiB": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Total GPU memory in GiB"
+            },
+            "allocatedTo": {
+              "type": "string",
+              "description": "If set, identifies the workload/deployment claiming this GPU. Empty string means unallocated."
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Example:**
+
+```json
+{
+  "id": "deviceprofile.margo.org/peripherals/gpu",
   "spec": {
     "gpus": [
       {
@@ -367,57 +537,96 @@ Replaces `peripherals` entries of type `gpu`.
 }
 ```
 
-#### `capability.margo.org/interface/ethernet`
+**Note:** The `allocatedTo` field tracks logical assignment for orchestration purposes. It is distinct from real-time usage metrics, which are reported separately via observability channels. An empty `allocatedTo` means the GPU is available; any non-empty string value indicates logical claim to that GPU.
 
-Replaces `interfaces` entries of type `ethernet` and `wifi`.
+---
+
+#### `deviceprofile.margo.org/interface/ethernet`
+
+Replaces `interfaces` entries of type `ethernet` and `wifi`. Describes network interfaces available on the device.
+
+**Schema:**
 
 ```json
 {
-  "apiVersion": "margo.org/v1",
-  "kind": "CapabilityState",
-  "metadata": {
-    "id": "capability.margo.org/interface/ethernet"
-  },
+  "id": "deviceprofile.margo.org/interface/ethernet",
+  "spec": {
+    "type": "object",
+    "required": ["interfaces"],
+    "properties": {
+      "interfaces": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "required": ["name", "type"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Interface name (e.g., 'eth0', 'wlan0')"
+            },
+            "type": {
+              "type": "string",
+              "enum": ["ethernet", "wifi", "usb"],
+              "description": "Interface type"
+            },
+            "speed": {
+              "type": "string",
+              "description": "Link speed (e.g., '1Gbps', '300Mbps')"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Example:**
+
+```json
+{
+  "id": "deviceprofile.margo.org/interface/ethernet",
   "spec": {
     "interfaces": [
-      { "name": "eth0", "speed": "1Gbps" },
-      { "name": "wlan0", "speed": "300Mbps" }
+      { "name": "eth0", "type": "ethernet", "speed": "1Gbps" },
+      { "name": "wlan0", "type": "wifi", "speed": "300Mbps" }
     ]
   }
 }
 ```
 
-#### Vendor-defined example — `capability.acme.com/fieldbus/canbus`
+---
 
-Vendor-defined capabilities follow the same structure. The WFM stores the `spec` as-is if no schema is registered for the URI.
+#### Vendor-defined example — `deviceprofile.acme.com/fieldbus/canbus`
+
+Vendor-defined profile attributes follow the same structure. The vendor first needs to register the profile schema with WFM. The WFM rejects the profile state no schema is registered for the URI.
+
+**Example:**
 
 ```json
 {
-  "apiVersion": "margo.org/v1",
-  "kind": "CapabilityState",
-  "metadata": {
-    "id": "capability.acme.com/fieldbus/canbus"
-  },
+  "id": "deviceprofile.acme.com/fieldbus/canbus",
   "spec": {
     "channels": [
       {
         "channelId": "can0",
         "baudRate": 500000,
         "protocol": "CANopen",
-        "allocated": false,
-        "allocatedBy": ""
+        "allocatedTo": ""
       },
       {
         "channelId": "can1",
         "baudRate": 250000,
         "protocol": "J1939",
-        "allocated": true,
-        "allocatedBy": "deployment-sensor-monitor-003"
+        "allocatedTo": "deployment-sensor-monitor-003"
       }
     ]
   }
 }
 ```
+
+**Note:** Like the GPU example, `allocatedTo` (or similar allocation-tracking fields) distinguishes logical assignment from real-time usage.
 
 ---
 
@@ -425,33 +634,65 @@ Vendor-defined capabilities follow the same structure. The WFM stores the `spec`
 
 | Field | Baseline (post roles-SUP) | After This SUP |
 |-------|--------------------------|----------------|
-| `id`, `vendor`, `modelNumber`, `serialNumber` | In `DeviceCapabilitiesManifest` | Moved to `DeviceManifest` — separate endpoint |
-| `cpu` | Flat array in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/compute/cpu` |
-| `memory` | Flat field in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/compute/memory` |
-| `storage` | Flat field in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/compute/storage` |
-| `otelCollector` | Flat boolean in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/service/otel-collector` |
-| `supportedRuntimes` | Flat array in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/runtime/supported` |
-| `supportedDeploymentTypes` | Flat array in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/runtime/supported` |
-| `peripherals` | Flat enum | Removed — expressed as `CapabilityState` per hardware type |
-| `interfaces` | Flat enum | Removed — expressed as `CapabilityState` per interface type |
+| `id`, `vendor`, `modelNumber`, `serialNumber` | In `DeviceCapabilitiesManifest` | Moved to `DeviceManifest` — separate endpoint, simplified schema |
+| `cpu` | Flat array in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/resource/cpu` with formal schema |
+| `memory` | Flat field in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/resource/memory` with formal schema |
+| `storage` | Flat field in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/resource/storage` with formal schema |
+| `otelCollector` | Flat boolean in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/service/otel-collector` with formal schema |
+| `supportedRuntimes` | Flat array in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/capability/runtimes` with formal schema |
+| `supportedDeploymentTypes` | Flat array in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/capability/runtimes` with formal schema |
+| `peripherals` | Flat enum | Removed — expressed as `ProfileState` per hardware type, with allocation metadata |
+| `interfaces` | Flat enum | Removed — expressed as `ProfileState` per interface type |
 | Gateway hierarchy encoding | In endpoint path | Unchanged — retained on both new endpoint groups |
-| Onboarding order | Single document | `DeviceManifest` MUST precede first `CapabilityState` |
-| Update granularity | Entire document re-sent | One `CapabilityState` per capability, updated independently |
+| Onboarding order | Single document | `DeviceManifest` MUST precede first `ProfileState` |
+| Update granularity | Entire document re-sent | One `ProfileState` per attribute; bulk array option available for onboarding |
+
+---
+
+## Important Semantic Distinctions
+
+This proposal makes important distinctions between different types of device state:
+
+### Capacity vs. Allocation vs. Usage
+
+- **Capacity** — The total amount of a resource available (e.g., total CPU cores, total GPU memory). Reported via profile state, changes infrequently.
+- **Allocation** — Which workloads or deployments claim which resources (e.g., "GPU 0 is allocated to deployment X"). Reported via profile state fields like `allocatedTo`, changes when workloads are scheduled.
+- **Usage/Metrics** — Real-time consumption of resources (e.g., current CPU utilization, GPU memory in use). Reported via separate observability channels, not via device profile state.
+
+The device profile state mechanism is appropriate for reporting capacity and allocation metadata. Real-time usage metrics should use the observability framework instead.
+
+---
+
+## Profile Pattern Extensibility
+
+The Device Profile concept introduced here is intentionally reusable across the Margo ecosystem:
+
+- **Device Profile** (`deviceprofile.margo.org/*`) — Describes what resources, services, and capabilities are available on a device
+- **Workload Profile** (`workloadprofile.margo.org/*`, future) — Could describe workload requirements, constraints, and expected capabilities
+- **Workflow Profile** (`workflowprofile.margo.org/*`, future) — Could describe workflow execution environment needs and service dependencies
+- **Gateway Profile** (`gatewayprofile.margo.org/*`, future) — Could describe gateway-specific resources and services
+
+This creates a consistent mental model across the Margo specification ecosystem where any entity's profile is a structured collection of attributes organized by category (resource, interface, peripheral, service, capability).
 
 ---
 
 ## Alternatives Considered
 
-**Keep a single endpoint, split the schema into two sub-objects.** Rejected. Separate endpoints make the lifecycle difference explicit — the WFM can apply different caching, validation, and update logic to identity vs capability data without inferring it from the payload structure.
+**Keep a single endpoint, rename to indicate broader scope.** Rejected. Separate endpoints make the lifecycle difference explicit — the WFM can apply different caching, validation, and update logic to identity vs. profile data without inferring it from the payload structure.
 
-**Keep `peripherals` and `interfaces` as deprecated fields alongside `capabilities[]`.** Rejected. Keeping deprecated fields creates ambiguity about which is authoritative when both are present. A clean removal forces implementations to adopt the structured model immediately and avoids a dual-path validation burden on the WFM.
+**Keep `peripherals` and `interfaces` as deprecated fields alongside profile state.** Rejected. Keeping deprecated fields creates ambiguity about which is authoritative when both are present. A clean removal forces implementations to adopt the structured model immediately and avoids a dual-path validation burden on the WFM.
 
-**Wrap all capabilities in a `DeviceCapabilitiesManifest` array.** Rejected. A wrapping manifest requires re-sending all capabilities to update one. Individual `CapabilityState` documents allow the device to update a single capability (e.g. GPU allocation state changed) without touching others.
+**Wrap all profile attributes in a `DeviceProfileManifest` array.** Rejected. A wrapping manifest requires re-sending all attributes to update one. Individual `ProfileState` documents (with optional bulk array support) allow the device to update a single attribute (e.g., GPU allocation state) without touching others.
 
-**Encode the capability URI in the endpoint path.** Rejected. The `CapabilityState` document already carries the URI in `metadata.id`. Duplicating it in the path adds no information and introduces encoding complexity for URIs containing slashes.
+**Encode the profile URI in the endpoint path.** Rejected. The `ProfileState` document already carries the URI in `id`. Duplicating it in the path adds no information and introduces encoding complexity for URIs containing slashes.
+
 
 ---
 
 ## Open Questions
 
-1. Gateway capability reporting — opaque and see-thru gateway `CapabilityState` update semantics following Gateway SUP injection. To be addressed in a follow-on proposal.
+1. **Schema registry** — Should formal schema specifications (as provided above) be stored separately and versioned, or embedded inline in this SUP?
+
+2. **Allocation tracking scope** — Should `allocatedTo` (or similar) be present in all allocatable resources, or only those where dynamic allocation is actually needed?
+
+3. **Service profile standardization** — Which platform services (vault, DNS, etc.) should have standardized profiles in Margo, and what should their schemas be?

--- a/proposals/sup_bisect_device_manifest.md
+++ b/proposals/sup_bisect_device_manifest.md
@@ -10,26 +10,15 @@
 
 ## Summary
 
-The `sup_device_roles_to_capabilities` SUP removed `roles` and promoted all device fields to the `properties` root. The resulting `DeviceCapabilitiesManifest` still conflates two distinct concerns:
-
-- **Device identity** — `id`, `vendor`, `modelNumber`, `serialNumber`. Static after onboarding. Never changes.
-- **Device profile information** — `cpu`, `memory`, `storage`, `otelCollector`, `supportedRuntimes`, `supportedDeploymentTypes`, `peripherals`, `interfaces`. Changes primarily when hardware is added/removed or runtime support is modified.
-
-This proposal:
-
-1. Bisects the `DeviceCapabilitiesManifest` into two separate documents with separate endpoints: **DeviceManifest** (identity only) and individual **ProfileState** documents (one per device profile attribute).`
-2. Introduces the concept of **Device Profile** — a structured description of all hardware resources, interfaces, peripherals, and services available on a device.
-3. Removes the flat `peripherals` and `interfaces` enumerations entirely.
-4. Promotes all profile data — including base compute fields and services — into structured `ProfileState` documents, each posted individually to the profile endpoint.
-5. Simplifies the `ProfileState` schema to remove unnecessary wrapper fields.
-6. Provides formal schema specifications for each standard profile URI.
+This proposal splits the `DeviceCapabilitiesManifest` into a distinct `DeviceManifest` for static identity and `ProfileState` documents for dynamic resource reporting. It introduces `ProfileDefinition` as an authoritative schema for device profiles, eliminating hardcoded fields and enabling structured, extensible capability reporting.
 
 ---
 
 ## Baseline
 
-This proposal modifies the schema produced by `sup_device_roles_to_capabilities`. The current baseline after that SUP is:
+This proposal replaces the old schema format created by `sup_device_roles_to_capabilities`. In that all device identity and resource data were crammed into one single object called the DeviceCapabilitiesManifest.
 
+The Old Format:
 ```json
 {
   "apiVersion": "device.margo.org/v1alpha1",
@@ -51,69 +40,166 @@ This proposal modifies the schema produced by `sup_device_roles_to_capabilities`
 }
 ```
 
+This proposal completely eliminates this combined format and rebuilds the way features are reported from scratch.
+
 ---
 
 ## Reason for Proposal
 
-### Problem 1 — Identity and profile information are coupled in a single document
+### Problem 1: Identity and resources are mixed together
+Identity data rarel changes. Resource related data changes often. Sending them together creates major issues: 
 
-Identity fields (`id`, `vendor`, `modelNumber`, `serialNumber`) never change after onboarding. Profile fields change infrequently — only when hardware is added/removed or when runtime support is modified. Sending both together means:
+* Wasted data: Resource updates force you to resend unchanged identity details.
+* Confusion: The system cannot separate a serial number fix from a hardware change.
+* No independent updates: You cannot version or evolve identity fields and resource fields separately.
 
-- A profile update forces re-sending identity data that has not changed
-- The WFM cannot distinguish an identity change from a profile change
-- The two concerns cannot evolve or be versioned independently
+### Problem 2: Limited descriptions for hardware and networks
+The current setup uses basic labels that cannot share real-world details.
 
-### Problem 2 — `peripherals` and `interfaces` use closed enumerations that cannot express structured state
+* A graphics card (GPU) can only list its type and manufacturer. It cannot show its VRAM size, system path, or architecture.
+* A network connection (like CAN Bus) can only list its type. It cannot show its speed, protocol, or channel ID.
 
-A GPU reported as:
+### Problem 3: Basic computing fields cannot grow
+Standard fields like cpu, memory, and storage are treated as rigid, flat text blocks. You cannot expand their rules. They need to become standalone profile files with their own flexible rulebooks.
 
-```json
-{ "type": "gpu", "manufacturer": "NVIDIA" }
+### Problem 4: Hardware types are hardcoded
+Adding a new piece of hardware (like an AI accelerator or secure chip) forces a complete update to the core system specification. This creates a bottleneck. Device makers cannot launch new features until the main community updates the global rules.
+
+---
+
+## Introducing the Profile Framework
+
+A Profile is a specific resource, service, capability or settings on a device/wfm (like a GPU, local storage, vault service). To keep data organized, every Profile is split into two parts: its rules (ProfileDefinition) and its actual live data (ProfileState).
+
+```
+ProfileDefinition  →  defines the contract (schema, scope, ownership, category)
+ProfileState       →  runtime data conforming to that contract
 ```
 
-Cannot express VRAM, device path, allocation state, or compute architecture. A CAN Bus interface reported as:
+Devices send out many `ProfileState` documents after onboarding and update them when there are changes. Every `ProfileState` must conform to the rules written in its matching `ProfileDefinition` blueprint.
+
+---
+
+### ProfileDefinition
+
+A `ProfileDefinition` is authored once — by Margo Community, a device vendor, or a WFM vendor — and registered with WFM. It establishes five things:
+
+- **What** this profile is — its URI, category, and description
+- **Who** owns the profile — scope : device-scoped (Device Agent) or fleet-scoped (WFM)
+- **What category** it belongs to — resource, interface, peripheral, service, or capability
+- **What format** the runtime data reporting must use
+
+**Example ProfileDefinition:**
 
 ```json
-{ "type": "canbus" }
+{
+  "profileDefinitionId": "deviceprofile.margo.org/peripherals/gpu",
+  "description": "Profile Definition for GPU peripherals",
+  "scope": "device",
+  "category": "peripheral",
+  "schemaVersion": "1.0.0",
+  "platformStateSchema": {
+    "type": "object",
+    "required": ["gpus"],
+    "properties": {
+      "gpus": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "required": ["model", "manufacturer"],
+          "properties": {
+            "manufacturer": { "type": "string" },
+            "model": { "type": "string" },
+            "vram": { "type": "string" },
+            "architecture": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}
 ```
 
-Cannot express baud rate, protocol, channel identity, or allocation state.
+> Note: This document only covers the reported data format (i.e. `platformStateSchema`). A separate SUP (the [Resource Profile Discovery & Resolution SUP](https://github.com/margo/specification-enhancements/pull/66) introduces the mechanism of how apps find and request these profiles during deployment. That SUP will extend the `ProfileDefinition` to include discovery rules under the same document with the same URI.
+     
+**Fields:**
 
-### Problem 3 — Base compute fields lack a structured model for extension
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `profileDefinitionId` | string | Y | URI uniquely identifying this profile type. |
+| `scope` | enum | Y | `device` — owned and published by Device Agent, `fleet` - owned by WFM(not introduced in this SUP) |
+| `category` | enum | Y | One of `resource`, `interface`, `peripheral`, `service`, `capability`. Formally declares which category this profile belongs to. |
+| `schemaVersion` | string | Y | Semantic version of this `ProfileDefinition` schema (e.g. `1.0.0`). Used to detect schema evolution and trigger re-validation of existing `ProfileState` documents. |
+| `description` | string | Y | Human-readable description of this profile type. |
+| `platformStateSchema` | object | Y | The format for runtime data that platforms will report. |
 
-Fields like `cpu`, `memory`, `storage`, `otelCollector`, `supportedRuntimes`, and `supportedDeploymentTypes` are currently special-cased flat/scalar fields. There is no mechanism to extend their schema, express allocation metadata, or document their update semantics. Treating them as first-class `ProfileState` entries with formal schema specifications resolves this.
+---
+
+### ProfileDefinition Registration
+
+`ProfileDefinition` documents must be registered with the WFM before any `ProfileState` can reference them. Margo-defined definitions are pre-loaded as part of the WFM specification bundle. Vendor-defined definitions can also be side loaded into the WFM. There is no API endpoint in this SUP to register them.
+
+---
+
+### ProfileState
+
+A `ProfileState` is submitted by the profile owner after device onboarding and updated when hardware changes. The Device Agent submits it for device-scoped profiles.
+
+**Example:**
+
+```json
+[{
+  "profileDefinitionId": "deviceprofile.margo.org/peripherals/gpu",
+  "platformState": {
+    "gpus": [
+      {
+        "manufacturer": "NVIDIA",
+        "model": "A100",
+        "vram": "80Gi",
+        "architecture": "Ampere"
+      }
+    ]
+  }
+}]
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `profileDefinitionId` | string | Y | URI referencing the matching `ProfileDefinition`. The WFM uses this to locate the blueprint and validate `platformState`. |
+| `platformState` | object | Y | Runtime instance data. Must conform to the `platformStateSchema` of the referenced `ProfileDefinition`. |
 
 ---
 
 ## Introducing Device Profile
 
-This proposal introduces the concept of a **Device Profile** — a comprehensive description of all hardware resources, communication interfaces, physical peripherals, and platform services available on a device.
+A Device Profile is a complete list of everything a device has to offer. It describes all the hardware resources, communication tools, extra plug-in parts, and built-in software services available on that machine.
 
-A **Device Profile** encompasses:
+A Device Profile groups these features into five categories:
+* **Resources:** Countable hardware parts like CPU cores, system memory (RAM), and disk drive storage space.
+* **Interfaces:** Parts that connect the device to networks or other hardware, such as Ethernet ports, Wi-Fi chips, CAN Bus links, and USB ports.
+* **Peripherals:** Extra physical hardware parts built into or attached to the device, like graphics cards (GPUs), cameras, or microphones.
+* **Services:** Built-in software features run by the device itself, such as a secure password vault, a local DNS server, or an OpenTelemetry (OTel) log collector.
+* **Capabilities:** The actual actions the device can do (like processing AI models, encoding video files, or gathering system metrics) because it has the right mix of hardware and services.
 
-- **Resources** (CPU, Memory, Storage) — Quantifiable hardware resources
-- **Interfaces** (Ethernet, WiFi, CAN Bus, USB) — Communication and connectivity mechanisms
-- **Peripherals** (GPU, Camera, Microphone) — Specialized hardware components
-- **Services** (Secret Vault, DNS Server, OTeL Collector) — Platform-managed services
-- **Capabilities** (Video encoding, AI acceleration, observability collection) — Functional abilities enabled by hardware, services, or software
+## Important Difference: Things vs. Capabilities
 
-### Key Insight: Things vs. Capabilities
+To keep your configuration clear, do not confuse a physical thing with what that thing can do (its capability). Things are pieces of hardware or software services that work together to make a capability possible.
 
-A crucial distinction: not all profile attributes are themselves *capabilities*. Rather, they are platform-managed *resources* and *services* that collectively form the device's profile and enable certain capabilities:
+* A GPU (a thing) is not a capability. It is a part that makes AI acceleration and video encoding (capabilities) possible.
+* A Secret Vault (a thing) is not a capability. It is a service that makes secure password saving (a capability) possible.
+* An Ethernet Interface (a thing) is not a capability. It is a port that makes network communication (a capability) possible.
 
-- A **GPU** (peripheral) is not a capability, but it *enables* video encoding and AI acceleration (capabilities)
-- A **Secret Vault** (service) is not a capability, but it *enables* secure credential management (capability)
-- A **DNS Server** (service) is not a capability, but it *enables* IP address assignment (capability)
-- An **Ethernet interface** (interface) is not a capability, but it *enables* network communication (capability)
+A `ProfileDefinition` with `category: capability` MUST describe an action or outcome the device can perform — not a hardware part or software service. The WFM SHOULD warn if a capability `ProfileDefinition` is submitted whose `profileDefinitionId` path segment matches a known hardware or service type name.
 
-By treating all of these under the unified **Device Profile** concept, we can describe the complete environment available to workloads without conflating the *providers* of capabilities with the *capabilities* themselves.
+## Room to Grow (Future Profiles)
 
-### Pattern Extensibility
+The Device Profile design can be reused for other parts later on, but they are not introduced yet in this SUP. Similar profiles could be defined for:
 
-This Device Profile pattern is designed to be reusable beyond devices but they are not introduced yet in this SUP but similar profiles could be defined for:
-
-- **WFM Profile** — describing fleet manager managed resources and services
-- **Gateway Profile** — describing gateway-specific resources and services
+* **WFM Profiles:** To describe fleet manager managed resources and services.
+* **Gateway Profiles:** To describe gateway specific resources and services.
 
 This creates a consistent mental model across the Margo ecosystem.
 
@@ -123,7 +209,7 @@ This creates a consistent mental model across the Margo ecosystem.
 
 ### New Endpoints
 
-The existing combined endpoint is replaced by two separate endpoint groups:
+The existing `DeviceCapabilitiesManifest` endpoint is replaced by two separate endpoint groups:
 
 ```
 # Device identity
@@ -132,25 +218,56 @@ PUT    /api/v1/clients/{clientId}/devices/{deviceId}
 DELETE /api/v1/clients/{clientId}/devices/{deviceId}
 
 # Device profile state
-POST   /api/v1/clients/{clientId}/devices/{deviceId}/profile
-PUT    /api/v1/clients/{clientId}/devices/{deviceId}/profile
-DELETE /api/v1/clients/{clientId}/devices/{deviceId}/profile
+POST   /api/v1/clients/{clientId}/devices/{deviceId}/profiles
+PUT    /api/v1/clients/{clientId}/devices/{deviceId}/profiles
+DELETE /api/v1/clients/{clientId}/devices/{deviceId}/profiles
 ```
 
 **Ordering requirement:** `DeviceManifest` MUST be registered before any `ProfileState` can be submitted for the same `deviceId`. If the WFM receives a `ProfileState` for an unknown `deviceId`, it MUST reject with `404 Not Found`.
 
-**Update granularity:**
-- **Bulk updates:** Each POST or PUT to the profile endpoint carries an array of `ProfileState` documents in a single request to reduce chattiness:
-  ```json
-  [
-    { "id": "deviceprofile.margo.org/resource/cpu", "spec": { ... } },
-    { "id": "deviceprofile.margo.org/resource/memory", "spec": { ... } },
-    { "id": "deviceprofile.margo.org/peripherals/gpu", "spec": { ... } }
-  ]
-  ```
-  The WFM processes all items atomically: either all succeed or all fail.
+**Scope enforcement:** The WFM MUST verify that the submitting client matches the `scope` declared in the referenced `ProfileDefinition`:
+- Violations MUST be rejected with `403 Forbidden`.
 
-**Gateway hierarchy:** The `{deviceId}` path hierarchy encoding (e.g. `gateway1/deviceA`) is retained unchanged on both endpoint groups.
+**Update granularity — bulk operations:**
+
+Each POST or PUT to the profile endpoint carries an array of `ProfileState` documents in a single request:
+
+```json
+[
+  {
+    "profileDefinitionId": "deviceprofile.margo.org/resource/cpu",
+    "platformState": { }
+  },
+  {
+    "profileDefinitionId": "deviceprofile.margo.org/peripherals/gpu",
+    "platformState": { }
+  }
+]
+```
+
+The WFM processes all items atomically: either all succeed or all fail. When a batch fails, the WFM MUST return a `422 Unprocessable Content` response identifying which `profileDefinitionId` caused the failure:
+
+```json
+{
+  "error": "Validation failed",
+  "failures": [
+    {
+      "profileDefinitionId": "deviceprofile.margo.org/peripherals/gpu",
+      "reason": "incorrect format"
+    }
+  ]
+}
+```
+
+**Gateway hierarchy submission rules:**
+- A gateway MAY submit `ProfileState` documents on behalf of child devices using the hierarchical `{deviceId}` path (e.g. `gateway1/deviceA`).
+- The gateway's client certificate MUST be authorized for the parent `clientId`.
+- Scope enforcement applies to the gateway client role, not the child device.
+- The `{deviceId}` path hierarchy encoding is retained unchanged on all endpoint groups.
+
+**DeviceManifest deletion cascade:**
+- When a `DeviceManifest` is deleted, the WFM MUST automatically and atomically delete all associated `ProfileState` documents for that `deviceId`.
+- The WFM MUST NOT leave orphaned `ProfileState` documents after a `DeviceManifest` deletion.
 
 ---
 
@@ -163,9 +280,9 @@ DELETE /api/v1/clients/{clientId}/devices/{deviceId}/profile
 | `204 No Content` | Document was deleted successfully. |
 | `400 Bad Request` | Missing or invalid `content-digest` header, or malformed request body. |
 | `401 Unauthorized` | Signature verification failed. |
-| `403 Forbidden` | Client certificate is not trusted or has been revoked. |
-| `404 Not Found` | No client with the given `clientId` found, or no `DeviceManifest` registered for the given `deviceId` (profile endpoint only). |
-| `422 Unprocessable Content` | Request body includes a semantic error. |
+| `403 Forbidden` | Client certificate is not trusted, has been revoked, or the submitting client does not match the `scope` of the referenced `ProfileDefinition`. |
+| `404 Not Found` | No client with the given `clientId` found, or no `DeviceManifest` registered for the given `deviceId`. |
+| `422 Unprocessable Content` | `platformState` does not conform to `platformStateSchema`, `profileDefinitionId` references an unregistered `ProfileDefinition`, capability dependency not satisfied, or batch contains semantic errors. Response body MUST identify the failing `profileDefinitionId` and reason. |
 
 ---
 
@@ -179,7 +296,7 @@ Carries device identity only. Sent once at onboarding. Updated only if identity 
 
 ```json
 {
-  "id": "northstarida.xtapro.k8s.edge",
+  "deviceId": "northstarida.xtapro.k8s.edge",
   "vendor": "Northstar Industrial Devices",
   "modelNumber": "332ANZE1-N1",
   "serialNumber": "PF45343-AA"
@@ -190,88 +307,29 @@ Carries device identity only. Sent once at onboarding. Updated only if identity 
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `id` | string | Y | Unique device identifier. Must include only unreserved characters as specified in RFC3986 plus the path separator `/`. |
+| `deviceId` | string | Y | Unique device instance identifier. Distinct from `profileDefinitionId` which is a type reference URI. |
 | `vendor` | string | Y | Device vendor name. |
 | `modelNumber` | string | Y | Device model number. |
 | `serialNumber` | string | Y | Device serial number. |
 
 ---
 
-### ProfileState
-
-Each device profile attribute is submitted as an individual `ProfileState` document.
-
-**Endpoint:** `POST /api/v1/clients/{clientId}/devices/{deviceId}/profile`
-
-The WFM uses `id` to identify which profile attribute is being registered or updated. Submitting a `ProfileState` for a profile URI that already exists for the device replaces the previous state.
-
-**Document structure:**
-
-```json
-{
-  "id": "<profile-uri>",
-  "spec": {
-    // profile-specific state object
-  }
-}
-```
-
-**Fields:**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `id` | string | Y | URI identifying the profile attribute type. Determines the schema of `spec`. |
-| `spec` | object | Y | State information for this profile attribute. Content is governed by the schema for the referenced profile URI. |
-
-**DELETE — removing a profile attribute:**
-
-To remove a profile attribute from a device (e.g. hardware was physically removed), send a DELETE request with the profile URI in the request body:
-
-```
-DELETE /api/v1/clients/{clientId}/devices/{deviceId}/profile
-```
-
-```json
-{
-  "id": "deviceprofile.margo.org/peripherals/gpu"
-}
-```
-
-The WFM MUST remove the stored `ProfileState` for the given profile URI against the given device.
+### Migrating DeviceCapabilitiesManifest Fields to Standalone Profiles
 
 ---
-
-### Profile URI Namespace
-
-Profile URIs follow a reverse-DNS convention and include a category prefix indicating the type of profile information:
-
-| Namespace | Category | Owner | Example |
-|-----------|----------|-------|---------|
-| `deviceprofile.margo.org/resource/*` | Hardware resources | Margo specification | `deviceprofile.margo.org/resource/cpu` |
-| `deviceprofile.margo.org/interface/*` | Communication interfaces | Margo specification | `deviceprofile.margo.org/interface/ethernet` |
-| `deviceprofile.margo.org/peripherals/*` | Peripheral hardware | Margo specification | `deviceprofile.margo.org/peripherals/gpu` |
-| `deviceprofile.margo.org/service/*` | Platform services | Margo specification | `deviceprofile.margo.org/service/vault` |
-| `deviceprofile.margo.org/capability/*` | Functional capabilities | Margo specification | `deviceprofile.margo.org/capability/video-encoding` |
-| `deviceprofile.<vendor-domain>/*` | Vendor-defined profile attributes | Vendor | `deviceprofile.acme.com/fieldbus/profinet` |
-
-The WFM MUST accept any well-formed URI in `id`. It MUST validate `spec` content against the schema for the referenced URI if a schema is registered. If no schema is registered for the URI, the WFM MUST report a rejection.
-
----
-
-### Standard Profile URIs Introduced by This SUP
-
-The following profile URIs replace the flat fields from the baseline schema. All are under the `deviceprofile.margo.org` namespace. Each includes a formal schema specification.
 
 #### `deviceprofile.margo.org/resource/cpu`
 
-Replaces the `cpu` array field. Describes the total CPU capacity of the device.
-
-**Schema:**
+**ProfileDefinition:**
 
 ```json
 {
-  "id": "deviceprofile.margo.org/resource/cpu",
-  "spec": {
+  "profileDefinitionId": "deviceprofile.margo.org/resource/cpu",
+  "description": "Profile Definition for CPU resources",
+  "scope": "device",
+  "category": "resource",
+  "schemaVersion": "1.0.0",
+  "platformStateSchema": {
     "type": "object",
     "required": ["cpus"],
     "properties": {
@@ -280,14 +338,14 @@ Replaces the `cpu` array field. Describes the total CPU capacity of the device.
         "minItems": 1,
         "items": {
           "type": "object",
-          "required": ["coreUnit", "cores", "architecture"],
+          "required": ["unit", "value", "architecture"],
           "properties": {
-            "coreUnit": {
+            "unit": {
               "type": "string",
               "enum": ["millicore", "core"],
-              "description": "The unit for cpu cores",
+              "description": "The unit for CPU cores"
             },
-            "cores": {
+            "value": {
               "type": "integer",
               "minimum": 1,
               "description": "Number of CPU cores"
@@ -309,14 +367,14 @@ Replaces the `cpu` array field. Describes the total CPU capacity of the device.
 }
 ```
 
-**Example:**
+**ProfileState Example:**
 
 ```json
 {
-  "id": "deviceprofile.margo.org/resource/cpu",
-  "spec": {
+  "profileDefinitionId": "deviceprofile.margo.org/resource/cpu",
+  "platformState": {
     "cpus": [
-      { "coreUnit": "core", "cores": 24, "architecture": "amd64", "model": "Intel Xeon" }
+      { "unit": "core", "value": 24, "architecture": "amd64", "model": "Intel Xeon" }
     ]
   }
 }
@@ -326,27 +384,33 @@ Replaces the `cpu` array field. Describes the total CPU capacity of the device.
 
 #### `deviceprofile.margo.org/resource/memory`
 
-Replaces the `memory` field. Describes the total system memory capacity (does not change unless physical memory is upgraded).
-
-**Schema:**
+**ProfileDefinition:**
 
 ```json
 {
-  "id": "deviceprofile.margo.org/resource/memory",
-  "spec": {
+  "profileDefinitionId": "deviceprofile.margo.org/resource/memory",
+  "description": "Profile Definition for system memory resources",
+  "scope": "device",
+  "category": "resource",
+  "schemaVersion": "1.0.0",
+  "platformStateSchema": {
     "type": "object",
     "required": ["total"],
     "properties": {
       "total": {
         "type": "object",
-        "description": "Total memory in units(Gi, Mi, etc.)",
+        "required": ["unit", "value"],
+        "description": "Total system memory",
         "properties": {
-          "memoryUnit": {
+          "unit": {
             "type": "string",
-            "enum": ["bytes", "Ki", "Mi", "Gi"]
+            "enum": ["bytes", "Ki", "Mi", "Gi"],
+            "description": "Binary unit for memory measurement"
           },
-          "memory": {
-            "type": "integer"
+          "value": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Total memory value in the specified unit"
           }
         }
       }
@@ -355,16 +419,13 @@ Replaces the `memory` field. Describes the total system memory capacity (does no
 }
 ```
 
-**Example:**
+**ProfileState Example:**
 
 ```json
 {
-  "id": "deviceprofile.margo.org/resource/memory",
-  "spec": {
-    "total": {
-      "memoryUnit": "Gi",
-      "memory": 59
-    }
+  "profileDefinitionId": "deviceprofile.margo.org/resource/memory",
+  "platformState": {
+    "total": { "unit": "Gi", "value": 59 }
   }
 }
 ```
@@ -373,27 +434,33 @@ Replaces the `memory` field. Describes the total system memory capacity (does no
 
 #### `deviceprofile.margo.org/resource/storage`
 
-Replaces the `storage` field. Describes the total persistent storage capacity (does not change unless physical storage is upgraded).
-
-**Schema:**
+**ProfileDefinition:**
 
 ```json
 {
-  "id": "deviceprofile.margo.org/resource/storage",
-  "spec": {
+  "profileDefinitionId": "deviceprofile.margo.org/resource/storage",
+  "description": "Profile Definition for persistent storage resources",
+  "scope": "device",
+  "category": "resource",
+  "schemaVersion": "1.0.0",
+  "platformStateSchema": {
     "type": "object",
-    "required": ["available"],
+    "required": ["total"],
     "properties": {
       "total": {
         "type": "object",
-        "description": "Total memory in units(Gi, Mi, etc.) or SI units (G, M, etc.)",
+        "required": ["unit", "value"],
+        "description": "Total persistent storage in binary units (Ki, Mi, Gi, Ti) or SI units (K, M, G, T)",
         "properties": {
-          "memoryUnit": {
+          "unit": {
             "type": "string",
-            "enum": ["bytes", "Ki", "Mi", "Gi"]
+            "enum": ["bytes", "Ki", "Mi", "Gi", "Ti", "K", "M", "G", "T"],
+            "description": "Unit for storage measurement. Use binary units for binary-aligned storage and SI units for disk storage."
           },
-          "memory": {
-            "type": "integer"
+          "value": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Total storage value in the specified unit"
           }
         }
       }
@@ -402,92 +469,13 @@ Replaces the `storage` field. Describes the total persistent storage capacity (d
 }
 ```
 
-**Example:**
+**ProfileState Example:**
 
 ```json
 {
-  "id": "deviceprofile.margo.org/resource/storage",
-  "spec": {
-    "total": {
-      "memoryUnit": "Gi",
-      "memory": 1024
-    }
-  }
-}
-```
-
----
-
-#### `deviceprofile.margo.org/service/otel-collector`
-
-Replaces the `otelCollector` boolean field. Indicates whether the device has OTeL collection enabled.
-
-**Schema:**
-
-```json
-{
-  "id": "deviceprofile.margo.org/service/otel-collector",
-  "spec": {
-    "type": "object",
-    "required": ["present"],
-    "properties": {
-      "present": {
-        "type": "boolean",
-        "description": "Whether OTeL collection is enabled on this device"
-      }
-    }
-  }
-}
-```
-
-**Example:**
-
-```json
-{
-  "id": "deviceprofile.margo.org/service/otel-collector",
-  "spec": {
-    "present": true
-  }
-}
-```
-
----
-
-#### `deviceprofile.margo.org/capability/runtimes`
-
-Replaces the `supportedRuntimes` and `supportedDeploymentTypes` fields. Describes the runtime environments and deployment mechanisms supported by the device.
-
-**Schema:**
-
-```json
-{
-  "id": "deviceprofile.margo.org/capability/runtimes",
-  "spec": {
-    "type": "object",
-    "properties": {
-      "containerRuntimes": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "List of supported container/runtime standards (e.g., 'oci')"
-      },
-      "deploymentTypes": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "List of supported deployment mechanisms (e.g., 'helm', 'compose')"
-      }
-    }
-  }
-}
-```
-
-**Example:**
-
-```json
-{
-  "id": "deviceprofile.margo.org/capability/runtimes",
-  "spec": {
-    "containerRuntimes": ["oci"],
-    "deploymentTypes": ["helm", "compose"]
+  "profileDefinitionId": "deviceprofile.margo.org/resource/storage",
+  "platformState": {
+    "total": { "unit": "G", "value": 1862 }
   }
 }
 ```
@@ -496,14 +484,16 @@ Replaces the `supportedRuntimes` and `supportedDeploymentTypes` fields. Describe
 
 #### `deviceprofile.margo.org/peripherals/gpu`
 
-Replaces `peripherals` entries of type `gpu`. Describes GPU hardware available on the device, including allocation state for orchestration.
-
-**Schema:**
+**ProfileDefinition:**
 
 ```json
 {
-  "id": "deviceprofile.margo.org/peripherals/gpu",
-  "spec": {
+  "profileDefinitionId": "deviceprofile.margo.org/peripherals/gpu",
+  "description": "Profile Definition for GPU peripheral hardware",
+  "scope": "device",
+  "category": "peripheral",
+  "schemaVersion": "1.0.0",
+  "platformStateSchema": {
     "type": "object",
     "required": ["gpus"],
     "properties": {
@@ -512,21 +502,24 @@ Replaces `peripherals` entries of type `gpu`. Describes GPU hardware available o
         "minItems": 1,
         "items": {
           "type": "object",
-          "required": ["model", "architecture"],
+          "required": ["manufacturer"],
           "properties": {
-            "model": {
-              "type": "string",
-              "description": "GPU model name (e.g., 'NVIDIA A100')"
+            "manufacturer": { "type": "string", "description": "GPU manufacturer name" },
+            "model": { "type": "string", "description": "GPU model name" },
+            "vram": { 
+              "unit": {
+                "type": "string",
+                "enum": ["bytes", "Ki", "Mi", "Gi"],
+                "description": "Binary unit for memory measurement"
+              },
+              "value": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Total memory value in the specified unit"
+              },
+              "description": "Video RAM capacity (e.g. 80Gi)"
             },
-            "architecture": {
-              "type": "string",
-              "description": "GPU architecture (e.g., 'ampere', 'hopper')"
-            },
-            "vramGiB": {
-              "type": "number",
-              "minimum": 0,
-              "description": "Total GPU memory in GiB"
-            }
+            "architecture": { "type": "string", "description": "GPU compute architecture (e.g. Ampere)" }
           }
         }
       }
@@ -535,38 +528,38 @@ Replaces `peripherals` entries of type `gpu`. Describes GPU hardware available o
 }
 ```
 
-**Example:**
+**ProfileState Example:**
 
 ```json
 {
-  "id": "deviceprofile.margo.org/peripherals/gpu",
-  "spec": {
+  "profileDefinitionId": "deviceprofile.margo.org/peripherals/gpu",
+  "platformState": {
     "gpus": [
       {
-        "model": "NVIDIA A100",
-        "architecture": "ampere",
-        "vramGiB": 40,
-        "allocatedTo": ""
+        "manufacturer": "NVIDIA",
+        "model": "A100",
+        "vram": { "unit": "Gi", "value": 10 },
+        "architecture": "Ampere"
       }
     ]
   }
 }
 ```
 
-**Note:** The `allocatedTo` field tracks logical assignment for orchestration purposes. It is distinct from real-time usage metrics, which are reported separately via observability channels. An empty `allocatedTo` means the GPU is available; any non-empty string value indicates logical claim to that GPU.
-
 ---
 
 #### `deviceprofile.margo.org/interface/ethernet`
 
-Replaces `interfaces` entries of type `ethernet` and `wifi`. Describes network interfaces available on the device.
-
-**Schema:**
+**ProfileDefinition:**
 
 ```json
 {
-  "id": "deviceprofile.margo.org/interface/ethernet",
-  "spec": {
+  "profileDefinitionId": "deviceprofile.margo.org/interface/ethernet",
+  "description": "Profile Definition for Ethernet network interfaces",
+  "scope": "device",
+  "category": "interface",
+  "schemaVersion": "1.0.0",
+  "platformStateSchema": {
     "type": "object",
     "required": ["interfaces"],
     "properties": {
@@ -575,21 +568,9 @@ Replaces `interfaces` entries of type `ethernet` and `wifi`. Describes network i
         "minItems": 1,
         "items": {
           "type": "object",
-          "required": ["name", "type"],
+          "required": ["name"],
           "properties": {
-            "name": {
-              "type": "string",
-              "description": "Interface name (e.g., 'eth0', 'wlan0')"
-            },
-            "type": {
-              "type": "string",
-              "enum": ["ethernet", "wifi", "usb"],
-              "description": "Interface type"
-            },
-            "speed": {
-              "type": "string",
-              "description": "Link speed (e.g., '1Gbps', '300Mbps')"
-            }
+            "name": { "type": "string", "description": "Interface name (e.g. eth0)" }
           }
         }
       }
@@ -598,106 +579,248 @@ Replaces `interfaces` entries of type `ethernet` and `wifi`. Describes network i
 }
 ```
 
-**Example:**
+**ProfileState Example:**
 
 ```json
 {
-  "id": "deviceprofile.margo.org/interface/ethernet",
-  "spec": {
+  "profileDefinitionId": "deviceprofile.margo.org/interface/ethernet",
+  "platformState": {
     "interfaces": [
-      { "name": "eth0", "type": "ethernet", "speed": "1Gbps" },
-      { "name": "wlan0", "type": "wifi", "speed": "300Mbps" }
-    ]
-  }
-}
-```
-
----
-
-#### Vendor-defined example — `deviceprofile.acme.com/fieldbus/canbus`
-
-Vendor-defined profile attributes follow the same structure. The vendor first needs to register the profile schema with WFM. The WFM rejects the profile state no schema is registered for the URI.
-
-**Example:**
-
-```json
-{
-  "id": "deviceprofile.acme.com/fieldbus/canbus",
-  "spec": {
-    "channels": [
       {
-        "channelId": "can0",
-        "baudRate": 500000,
-        "protocol": "CANopen",
-        "allocatedTo": ""
-      },
-      {
-        "channelId": "can1",
-        "baudRate": 250000,
-        "protocol": "J1939",
-        "allocatedTo": "deployment-sensor-monitor-003"
+        "name": "eth0"
       }
     ]
   }
 }
 ```
 
-**Note:** Like the GPU example, `allocatedTo` (or similar allocation-tracking fields) distinguishes logical assignment from real-time usage.
+---
+
+#### Vendor Specific Extension : `deviceprofile.example.org/interface/canbus`
+
+**ProfileDefinition:**
+
+```json
+{
+  "profileDefinitionId": "deviceprofile.example.org/interface/canbus",
+  "description": "Profile Definition for CAN Bus interfaces",
+  "scope": "device",
+  "category": "interface",
+  "schemaVersion": "1.0.0",
+  "platformStateSchema": {
+    "type": "object",
+    "required": ["interfaces"],
+    "properties": {
+      "interfaces": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "required": ["channelId"],
+          "properties": {
+            "channelId": { "type": "string", "description": "CAN channel identifier (e.g. can0)" },
+            "baudRate": { "type": "integer", "description": "Baud rate in bits per second (e.g. 500000)" },
+            "protocol": { "type": "string", "enum": ["CAN2.0A", "CAN2.0B", "CANFD"], "description": "CAN protocol variant" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**ProfileState Example:**
+
+```json
+{
+  "profileDefinitionId": "deviceprofile.example.org/interface/canbus",
+  "platformState": {
+    "interfaces": [
+      { "channelId": "can0", "baudRate": 500000, "protocol": "CAN2.0B" }
+    ]
+  }
+}
+```
 
 ---
 
-## What Changes, What Stays the Same
+#### `deviceprofile.margo.org/service/otel-collector`
 
-| Field | Baseline (post roles-SUP) | After This SUP |
-|-------|--------------------------|----------------|
-| `id`, `vendor`, `modelNumber`, `serialNumber` | In `DeviceCapabilitiesManifest` | Moved to `DeviceManifest` — separate endpoint, simplified schema |
-| `cpu` | Flat array in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/resource/cpu` with formal schema |
-| `memory` | Flat field in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/resource/memory` with formal schema |
-| `storage` | Flat field in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/resource/storage` with formal schema |
-| `otelCollector` | Flat boolean in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/service/otel-collector` with formal schema |
-| `supportedRuntimes` | Flat array in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/capability/runtimes` with formal schema |
-| `supportedDeploymentTypes` | Flat array in `DeviceCapabilitiesManifest` | `ProfileState` — `deviceprofile.margo.org/capability/runtimes` with formal schema |
-| `peripherals` | Flat enum | Removed — expressed as `ProfileState` per hardware type, with allocation metadata |
-| `interfaces` | Flat enum | Removed — expressed as `ProfileState` per interface type |
-| Gateway hierarchy encoding | In endpoint path | Unchanged — retained on both new endpoint groups |
-| Onboarding order | Single document | `DeviceManifest` MUST precede first `ProfileState` |
-| Update granularity | Entire document re-sent | One `ProfileState` per attribute; bulk array option available for onboarding |
+**ProfileDefinition:**
+
+```json
+{
+  "profileDefinitionId": "deviceprofile.margo.org/service/otel-collector",
+  "description": "Profile Definition for the OpenTelemetry collector service",
+  "scope": "device",
+  "category": "service",
+  "schemaVersion": "1.0.0",
+  "platformStateSchema": {
+    "type": "object",
+    "required": ["endpoint"],
+    "properties": {
+      "endpoint": {
+        "type": "string",
+        "description": "The OTEL collector service endpoints"
+      }
+    }
+  }
+}
+```
+
+**ProfileState Example:**
+
+```json
+{
+  "profileDefinitionId": "deviceprofile.margo.org/service/otel-collector",
+  "platformState": { "endpoint": "http://localhost:4317" }
+}
+```
+
+---
+
+#### `deviceprofile.margo.org/capability/runtimes`
+
+**ProfileDefinition:**
+
+```json
+{
+  "profileDefinitionId": "deviceprofile.margo.org/capability/runtimes",
+  "description": "Profile Definition for supported container runtimes and deployment types",
+  "scope": "device",
+  "category": "capability",
+  "schemaVersion": "1.0.0",
+  "platformStateSchema": {
+    "type": "object",
+    "required": ["containerRuntimes", "deploymentTypes"],
+    "properties": {
+      "containerRuntimes": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "type": "string" },
+        "description": "List of supported container runtime standards (e.g. oci)"
+      },
+      "deploymentTypes": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "type": "string" },
+        "description": "List of supported deployment mechanisms (e.g. helm, compose)"
+      }
+    }
+  }
+}
+```
+
+**ProfileState Example:**
+
+```json
+{
+  "profileDefinitionId": "deviceprofile.margo.org/capability/runtimes",
+  "platformState": {
+    "containerRuntimes": ["oci"],
+    "deploymentTypes": ["helm", "compose"]
+  }
+}
+```
 
 ---
 
-## Important Semantic Distinctions
+## Complete End-to-End Submission Example
 
-This proposal makes important distinctions between different types of device state:
+**Step 1 — Register DeviceManifest:**
 
-### Capacity vs. Allocation vs. Usage
+```
+POST /api/v1/clients/{clientId}/devices/{deviceId}
+```
 
-- **Capacity** — The total amount of a resource available (e.g., total CPU cores, total GPU memory). Reported via profile state, changes infrequently.
-- **Allocation** — Which workloads or deployments claim which resources (e.g., "GPU 0 is allocated to deployment X"). Reported via profile state fields like `allocatedTo`, changes when workloads are scheduled.
-- **Usage/Metrics** — Real-time consumption of resources (e.g., current CPU utilization, GPU memory in use). Reported via separate observability channels, not via device profile state.
+```json
+{
+  "deviceId": "northstarida.xtapro.k8s.edge",
+  "vendor": "Northstar Industrial Devices",
+  "modelNumber": "332ANZE1-N1",
+  "serialNumber": "PF45343-AA"
+}
+```
 
-The device profile state mechanism is appropriate for reporting capacity and allocation metadata. Real-time usage metrics should use the observability framework instead.
+**Step 2 — Submit Device Profile:**
 
-Note: This SUP doesn't disable the real-time metrices in the Profile State, but it is upto the Margo community to decide while authoring a Device Profile definition.
+```
+POST /api/v1/clients/{clientId}/devices/{deviceId}/profiles
+```
 
----
+```json
+[
+  {
+    "profileDefinitionId": "deviceprofile.margo.org/resource/cpu",
+    "platformState": {
+      "cpus": [
+        { "unit": "core", "value": 24, "architecture": "amd64", "model": "Intel Xeon" }
+      ]
+    }
+  },
+  {
+    "profileDefinitionId": "deviceprofile.margo.org/resource/memory",
+    "platformState": {
+      "total": { "unit": "Gi", "value": 59 }
+    }
+  },
+  {
+    "profileDefinitionId": "deviceprofile.margo.org/resource/storage",
+    "platformState": {
+      "total": { "unit": "G", "value": 1862 }
+    }
+  },
+  {
+    "profileDefinitionId": "deviceprofile.margo.org/peripherals/gpu",
+    "platformState": {
+      "gpus": [
+        {
+          "manufacturer": "NVIDIA",
+          "model": "A100",
+          "vram": { "unit": "Gi", "value": 10 },
+          "architecture": "Ampere"
+        }
+      ]
+    }
+  },
+  {
+    "profileDefinitionId": "deviceprofile.margo.org/interface/ethernet",
+    "platformState": {
+      "interfaces": [
+        {
+          "name": "eth0"
+        }
+      ]
+    }
+  },
+  {
+    "profileDefinitionId": "deviceprofile.margo.org/service/otel-collector",
+    "platformState": { "endpoint": "http://localhost:4317" }
+  },
+  {
+    "profileDefinitionId": "deviceprofile.margo.org/capability/runtimes",
+    "platformState": {
+      "containerRuntimes": ["oci"],
+      "deploymentTypes": ["helm", "compose"]
+    }
+  }
+]
+```
 
-## Profile Pattern Extensibility
+**Step 3 — Remove a single profile:**
 
-The Device Profile concept introduced here is intentionally reusable across the Margo ecosystem:
-
-- **Device Profile** (`deviceprofile.margo.org/*`) — Describes what resources, services, and capabilities are available on a device
-- **WFM Profile** (`wfmprofile.margo.org/*`, future) — Describe what resources, services and capabilities are available on WFM
-- **Gateway Profile** (`gatewayprofile.margo.org/*`, future) — Could describe gateway-specific resources and services
-
-This creates a consistent mental model across the Margo specification ecosystem where any entity's profile is a structured collection of attributes organized by category (resource, interface, peripheral, service, capability).
-
----
+```
+DELETE /api/v1/clients/{clientId}/devices/{deviceId}/profiles
+[
+  {
+    "profileDefinitionId": "deviceprofile.margo.org/capability/runtimes"
+  }
+]
+````
 
 ## Alternatives Considered
 
-**Keep a single endpoint, rename to indicate broader scope.** Rejected. Separate endpoints make the lifecycle difference explicit — the WFM can apply different caching, validation, and update logic to identity vs. profile data without inferring it from the payload structure.
-
-**Keep `peripherals` and `interfaces` as deprecated fields alongside profile state.** Rejected. Keeping deprecated fields creates ambiguity about which is authoritative when both are present. A clean removal forces implementations to adopt the structured model immediately and avoids a dual-path validation burden on the WFM.
+**Keep a single endpoint, rename to indicate broader scope.** Didn't consider as separate endpoints make the lifecycle difference explicit — the WFM can apply different caching, validation, and update logic to identity vs. profile data without inferring it from the payload structure.
 
 ---
 
@@ -705,6 +828,4 @@ This creates a consistent mental model across the Margo specification ecosystem 
 
 1. **Schema registry** — Should formal schema specifications (as provided above) be stored separately and versioned, or embedded inline in this SUP?
 
-2. **Allocation tracking scope** — Should `allocatedTo` (or similar) be present in all allocatable resources, or only those where dynamic allocation is actually needed?
-
-3. **Service profile standardization** — Which platform services (vault, DNS, etc.) should have standardized profiles in Margo, and what should their schemas be?
+2. **Service profile standardization** — Which platform services (vault, DNS, etc.) should have standardized profiles in Margo, and what should their schemas be?

--- a/proposals/sup_bisect_device_manifest.md
+++ b/proposals/sup_bisect_device_manifest.md
@@ -255,13 +255,7 @@ The WFM processes all items atomically: either all succeed or all fail. When it 
 
 **Gateway hierarchy submission rules:**
 - A gateway MAY submit `ProfileState` documents on behalf of child devices using the hierarchical `{deviceId}` path (e.g. `gateway1/deviceA`).
-- The gateway's client certificate MUST be authorized for the parent `clientId`.
-- Scope enforcement applies to the gateway client role, not the child device.
 - The `{deviceId}` path hierarchy encoding is retained unchanged on all endpoint groups.
-
-**DeviceManifest deletion cascade:**
-- When a `DeviceManifest` is deleted, the WFM MUST automatically and atomically delete all associated `ProfileState` documents for that `deviceId`.
-- The WFM MUST NOT leave orphaned `ProfileState` documents after a `DeviceManifest` deletion.
 
 ---
 

--- a/proposals/sup_bisect_device_manifest.md
+++ b/proposals/sup_bisect_device_manifest.md
@@ -17,7 +17,7 @@ The `sup_device_roles_to_capabilities` SUP removed `roles` and promoted all devi
 
 This proposal:
 
-1. Bisects the document into two separate documents with separate endpoints: **DeviceManifest** (identity only) and individual **ProfileState** documents (one per device profile attribute).
+1. Bisects the `DeviceCapabilitiesManifest` into two separate documents with separate endpoints: **DeviceManifest** (identity only) and individual **ProfileState** documents (one per device profile attribute).`
 2. Introduces the concept of **Device Profile** — a structured description of all hardware resources, interfaces, peripherals, and services available on a device.
 3. Removes the flat `peripherals` and `interfaces` enumerations entirely.
 4. Promotes all profile data — including base compute fields and services — into structured `ProfileState` documents, each posted individually to the profile endpoint.
@@ -110,10 +110,9 @@ By treating all of these under the unified **Device Profile** concept, we can de
 
 ### Pattern Extensibility
 
-This Device Profile pattern is designed to be reusable beyond devices. Similar profiles could be defined for:
+This Device Profile pattern is designed to be reusable beyond devices but they are not introduced yet in this SUP but similar profiles could be defined for:
 
-- **Workload Profile** — describing workload requirements and constraints
-- **Workflow Profile** — describing workflow execution environment needs
+- **WFM Profile** — describing fleet manager managed resources and services
 - **Gateway Profile** — describing gateway-specific resources and services
 
 This creates a consistent mental model across the Margo ecosystem.
@@ -141,8 +140,7 @@ DELETE /api/v1/clients/{clientId}/devices/{deviceId}/profile
 **Ordering requirement:** `DeviceManifest` MUST be registered before any `ProfileState` can be submitted for the same `deviceId`. If the WFM receives a `ProfileState` for an unknown `deviceId`, it MUST reject with `404 Not Found`.
 
 **Update granularity:**
-- **Individual updates (default):** Each POST or PUT to the profile endpoint carries exactly one `ProfileState` document. The WFM uses `id` to identify which profile attribute is being created or updated. Multiple attributes are registered by sending multiple requests.
-- **Bulk updates (optional):** Alternatively, clients MAY submit an array of `ProfileState` documents in a single request to reduce chattiness during initial onboarding:
+- **Bulk updates:** Each POST or PUT to the profile endpoint carries an array of `ProfileState` documents in a single request to reduce chattiness:
   ```json
   [
     { "id": "deviceprofile.margo.org/resource/cpu", "spec": { ... } },
@@ -266,7 +264,7 @@ The following profile URIs replace the flat fields from the baseline schema. All
 
 #### `deviceprofile.margo.org/resource/cpu`
 
-Replaces the `cpu` array field. Describes the total CPU capacity of the device (does not change unless physical hardware is replaced).
+Replaces the `cpu` array field. Describes the total CPU capacity of the device.
 
 **Schema:**
 
@@ -282,8 +280,13 @@ Replaces the `cpu` array field. Describes the total CPU capacity of the device (
         "minItems": 1,
         "items": {
           "type": "object",
-          "required": ["cores", "architecture"],
+          "required": ["coreUnit", "cores", "architecture"],
           "properties": {
+            "coreUnit": {
+              "type": "string",
+              "enum": ["millicore", "core"],
+              "description": "The unit for cpu cores",
+            },
             "cores": {
               "type": "integer",
               "minimum": 1,
@@ -313,7 +316,7 @@ Replaces the `cpu` array field. Describes the total CPU capacity of the device (
   "id": "deviceprofile.margo.org/resource/cpu",
   "spec": {
     "cpus": [
-      { "cores": 24, "architecture": "amd64", "model": "Intel Xeon" }
+      { "coreUnit": "core", "cores": 24, "architecture": "amd64", "model": "Intel Xeon" }
     ]
   }
 }
@@ -332,12 +335,20 @@ Replaces the `memory` field. Describes the total system memory capacity (does no
   "id": "deviceprofile.margo.org/resource/memory",
   "spec": {
     "type": "object",
-    "required": ["available"],
+    "required": ["total"],
     "properties": {
-      "available": {
-        "type": "string",
-        "pattern": "^\\d+\\s*(Gi|Mi|Ki|G|M|K)$",
-        "description": "Total memory in binary units (Gi, Mi, etc.) or SI units (G, M, etc.)"
+      "total": {
+        "type": "object",
+        "description": "Total memory in units(Gi, Mi, etc.)",
+        "properties": {
+          "memoryUnit": {
+            "type": "string",
+            "enum": ["bytes", "Ki", "Mi", "Gi"]
+          },
+          "memory": {
+            "type": "integer"
+          }
+        }
       }
     }
   }
@@ -350,7 +361,10 @@ Replaces the `memory` field. Describes the total system memory capacity (does no
 {
   "id": "deviceprofile.margo.org/resource/memory",
   "spec": {
-    "available": "59 Gi"
+    "total": {
+      "memoryUnit": "Gi",
+      "memory": 59
+    }
   }
 }
 ```
@@ -370,10 +384,18 @@ Replaces the `storage` field. Describes the total persistent storage capacity (d
     "type": "object",
     "required": ["available"],
     "properties": {
-      "available": {
-        "type": "string",
-        "pattern": "^\\d+\\s*(Gi|Mi|Ki|G|M|K)$",
-        "description": "Total storage in binary units (Gi, Mi, etc.) or SI units (G, M, etc.)"
+      "total": {
+        "type": "object",
+        "description": "Total memory in units(Gi, Mi, etc.) or SI units (G, M, etc.)",
+        "properties": {
+          "memoryUnit": {
+            "type": "string",
+            "enum": ["bytes", "Ki", "Mi", "Gi"]
+          },
+          "memory": {
+            "type": "integer"
+          }
+        }
       }
     }
   }
@@ -386,7 +408,10 @@ Replaces the `storage` field. Describes the total persistent storage capacity (d
 {
   "id": "deviceprofile.margo.org/resource/storage",
   "spec": {
-    "available": "1862 Gi"
+    "total": {
+      "memoryUnit": "Gi",
+      "memory": 1024
+    }
   }
 }
 ```
@@ -440,15 +465,15 @@ Replaces the `supportedRuntimes` and `supportedDeploymentTypes` fields. Describe
   "spec": {
     "type": "object",
     "properties": {
-      "runtimes": {
+      "containerRuntimes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of supported container/runtime standards (e.g., 'oci', 'wasm')"
+        "description": "List of supported container/runtime standards (e.g., 'oci')"
       },
       "deploymentTypes": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "List of supported deployment mechanisms (e.g., 'helm', 'compose', 'bare')"
+        "description": "List of supported deployment mechanisms (e.g., 'helm', 'compose')"
       }
     }
   }
@@ -461,7 +486,7 @@ Replaces the `supportedRuntimes` and `supportedDeploymentTypes` fields. Describe
 {
   "id": "deviceprofile.margo.org/capability/runtimes",
   "spec": {
-    "runtimes": ["oci"],
+    "containerRuntimes": ["oci"],
     "deploymentTypes": ["helm", "compose"]
   }
 }
@@ -487,12 +512,8 @@ Replaces `peripherals` entries of type `gpu`. Describes GPU hardware available o
         "minItems": 1,
         "items": {
           "type": "object",
-          "required": ["devicePath", "model"],
+          "required": ["model", "architecture"],
           "properties": {
-            "devicePath": {
-              "type": "string",
-              "description": "Device path (e.g., '/dev/nvidia0')"
-            },
             "model": {
               "type": "string",
               "description": "GPU model name (e.g., 'NVIDIA A100')"
@@ -505,10 +526,6 @@ Replaces `peripherals` entries of type `gpu`. Describes GPU hardware available o
               "type": "number",
               "minimum": 0,
               "description": "Total GPU memory in GiB"
-            },
-            "allocatedTo": {
-              "type": "string",
-              "description": "If set, identifies the workload/deployment claiming this GPU. Empty string means unallocated."
             }
           }
         }
@@ -526,7 +543,6 @@ Replaces `peripherals` entries of type `gpu`. Describes GPU hardware available o
   "spec": {
     "gpus": [
       {
-        "devicePath": "/dev/nvidia0",
         "model": "NVIDIA A100",
         "architecture": "ampere",
         "vramGiB": 40,
@@ -661,6 +677,8 @@ This proposal makes important distinctions between different types of device sta
 
 The device profile state mechanism is appropriate for reporting capacity and allocation metadata. Real-time usage metrics should use the observability framework instead.
 
+Note: This SUP doesn't disable the real-time metrices in the Profile State, but it is upto the Margo community to decide while authoring a Device Profile definition.
+
 ---
 
 ## Profile Pattern Extensibility
@@ -668,8 +686,7 @@ The device profile state mechanism is appropriate for reporting capacity and all
 The Device Profile concept introduced here is intentionally reusable across the Margo ecosystem:
 
 - **Device Profile** (`deviceprofile.margo.org/*`) — Describes what resources, services, and capabilities are available on a device
-- **Workload Profile** (`workloadprofile.margo.org/*`, future) — Could describe workload requirements, constraints, and expected capabilities
-- **Workflow Profile** (`workflowprofile.margo.org/*`, future) — Could describe workflow execution environment needs and service dependencies
+- **WFM Profile** (`wfmprofile.margo.org/*`, future) — Describe what resources, services and capabilities are available on WFM
 - **Gateway Profile** (`gatewayprofile.margo.org/*`, future) — Could describe gateway-specific resources and services
 
 This creates a consistent mental model across the Margo specification ecosystem where any entity's profile is a structured collection of attributes organized by category (resource, interface, peripheral, service, capability).
@@ -681,11 +698,6 @@ This creates a consistent mental model across the Margo specification ecosystem 
 **Keep a single endpoint, rename to indicate broader scope.** Rejected. Separate endpoints make the lifecycle difference explicit — the WFM can apply different caching, validation, and update logic to identity vs. profile data without inferring it from the payload structure.
 
 **Keep `peripherals` and `interfaces` as deprecated fields alongside profile state.** Rejected. Keeping deprecated fields creates ambiguity about which is authoritative when both are present. A clean removal forces implementations to adopt the structured model immediately and avoids a dual-path validation burden on the WFM.
-
-**Wrap all profile attributes in a `DeviceProfileManifest` array.** Rejected. A wrapping manifest requires re-sending all attributes to update one. Individual `ProfileState` documents (with optional bulk array support) allow the device to update a single attribute (e.g., GPU allocation state) without touching others.
-
-**Encode the profile URI in the endpoint path.** Rejected. The `ProfileState` document already carries the URI in `id`. Duplicating it in the path adds no information and introduces encoding complexity for URIs containing slashes.
-
 
 ---
 

--- a/proposals/sup_bisect_device_manifest.md
+++ b/proposals/sup_bisect_device_manifest.md
@@ -1,0 +1,457 @@
+# Specification Update Proposal — Device Manifest Bisection
+
+**Status:** Draft  
+**Owner:** @singhmj-1  
+**Depends on:** `sup_device_roles_to_capabilities`
+**Note:** This SUP has been extracted from [Resource Discovery and Conflict Resolution](https://github.com/margo/specification-enhancements/pull/66) SUP, as that one has become too complex.
+
+---
+
+## Summary
+
+The `sup_device_roles_to_capabilities` SUP removed `roles` and promoted all device fields to the `properties` root. The resulting `DeviceCapabilitiesManifest` still conflates two distinct concerns:
+
+- **Device identity** — `id`, `vendor`, `modelNumber`, `serialNumber`. Static after onboarding. Never changes.
+- **Device capabilities** — `cpu`, `memory`, `storage`, `otelCollector`, `supportedRuntimes`, `supportedDeploymentTypes`, `peripherals`, `interfaces`. Dynamic — updated as hardware and runtime state changes.
+
+This proposal:
+
+1. Bisects the document into two separate documents with separate endpoints: **DeviceManifest** (identity only) and individual **CapabilityState** documents (one per capability).
+2. Expands the definition of a capability.
+3. Removes the flat `peripherals` and `interfaces` enumerations entirely.
+4. Promotes all capability data — including base compute fields — into structured `CapabilityState` documents, each posted individually to the capabilities endpoint.
+5. Introduces the `CapabilityState` model inline, as the Capability Definition Framework SUP has not yet been formally introduced.
+
+---
+
+## Baseline
+
+This proposal modifies the schema produced by `sup_device_roles_to_capabilities`. The current baseline after that SUP is:
+
+```json
+{
+  "apiVersion": "device.margo.org/v1alpha1",
+  "kind": "DeviceCapabilitiesManifest",
+  "properties": {
+    "id": "northstarida.xtapro.k8s.edge",
+    "vendor": "Northstar Industrial Devices",
+    "modelNumber": "332ANZE1-N1",
+    "serialNumber": "PF45343-AA",
+    "cpu": [{ "cores": 24, "architecture": "amd64" }],
+    "memory": "59 Gi",
+    "storage": "1862 Gi",
+    "peripherals": [{ "type": "gpu", "manufacturer": "NVIDIA" }],
+    "interfaces": [{ "type": "ethernet" }, { "type": "wifi" }],
+    "otelCollector": true,
+    "supportedRuntimes": ["oci"],
+    "supportedDeploymentTypes": ["helm", "compose"]
+  }
+}
+```
+
+---
+
+## Reason for Proposal
+
+### Problem 1 — Identity and capabilities are coupled in a single document
+
+Identity fields (`id`, `vendor`, `modelNumber`, `serialNumber`) never change after onboarding. Capability fields change frequently — whenever workloads are deployed, hardware is added, or runtime configuration changes. Sending both together means:
+
+- A capability update forces re-sending identity data that has not changed
+- The WFM cannot distinguish a capability update from an identity change
+- The two concerns cannot evolve or be versioned independently
+
+### Problem 2 — `peripherals` and `interfaces` use closed enumerations that cannot express structured state
+
+A GPU reported as:
+
+```json
+{ "type": "gpu", "manufacturer": "NVIDIA" }
+```
+
+Cannot express VRAM, device path, allocation state, or compute architecture. A CAN Bus interface reported as:
+
+```json
+{ "type": "canbus" }
+```
+
+Cannot express baud rate, protocol, channel identity, or allocation state.
+
+### Problem 3 — Base compute fields are not capabilities in the structured sense
+
+Fields like `cpu`, `memory`, `storage`, `otelCollector`, `supportedRuntimes`, and `supportedDeploymentTypes` are currently special-cased flat/scalar fields. There is no mechanism to extend their schema, express allocation state, or update them independently of each other. Treating them as first-class `CapabilityState` entries resolves this.
+
+---
+
+## Expanding the Definition of Capability
+
+So far, the definition of a capability is restrictive, but this framework expands it:
+
+> A capability represents wide variety of **platform-managed concerns** 
+including the following:
+> * "Hardware resources" such as GPUs, cameras, fieldbus channels etc.
+> * "Software capabilities" such as persistent storage, pre-installed 
+runtimes etc.
+> * "Platform services" such as api gateways, security vaults, otel collectors 
+endpoints, pki, message buses etc.
+
+
+### Capability Model
+The current spec treats a "capability" as a flat enumeration value — a GPU is `{ "type": "gpu" }`, an interface is `{ "type": "ethernet" }`. This model cannot express runtime state, allocation, or structured metadata.
+
+This proposal introduces a richer capability model. A **CapabilityState** is a structured document that:
+
+- References a **capability URI** — a globally unique identifier for the capability type (e.g. `capability.margo.org/hardware/gpu`)
+- Carries a **spec** — a capability-specific object whose schema is defined by the capability type
+
+The capability URI is the key. It identifies not just the type of capability, but the schema that governs the `spec` content. This allows:
+
+- Vendors to define their own capability types under their own URI namespace (e.g. `capability.acme.com/fieldbus/profinet`)
+- The WFM to validate `spec` content against the schema for the referenced URI
+- Capabilities to be updated, added, or removed independently — one `CapabilityState` per capability, one request per update
+
+---
+
+## Technical Proposal
+
+### New Endpoints
+
+The existing combined endpoint is replaced by two separate endpoint groups:
+
+```
+# Device identity
+POST   /api/v1/clients/{clientId}/devices/{deviceId}
+PUT    /api/v1/clients/{clientId}/devices/{deviceId}
+DELETE /api/v1/clients/{clientId}/devices/{deviceId}
+
+# Individual capability states
+POST   /api/v1/clients/{clientId}/devices/{deviceId}/capabilities
+PUT    /api/v1/clients/{clientId}/devices/{deviceId}/capabilities
+DELETE /api/v1/clients/{clientId}/devices/{deviceId}/capabilities
+```
+
+**Ordering requirement:** `DeviceManifest` MUST be registered before any `CapabilityState` can be submitted for the same `deviceId`. If the WFM receives a `CapabilityState` for an unknown `deviceId`, it MUST reject with `404 Not Found`.
+
+**Individual updates:** Each POST or PUT to the capabilities endpoint carries exactly one `CapabilityState` document. The WFM uses `metadata.id` to identify which capability is being created or updated. Multiple capabilities are registered by sending multiple requests.
+
+**Gateway hierarchy:** The `{deviceId}` path hierarchy encoding (e.g. `gateway1/deviceA`) is retained unchanged on both endpoint groups.
+
+---
+
+### Response Codes
+
+| Code | Description |
+|------|-------------|
+| `201 Created` | Document was added successfully. |
+| `200 OK` | Document was updated successfully. |
+| `204 No Content` | Document was deleted successfully. |
+| `400 Bad Request` | Missing or invalid `content-digest` header, or malformed request body. |
+| `401 Unauthorized` | Signature verification failed. |
+| `403 Forbidden` | Client certificate is not trusted or has been revoked. |
+| `404 Not Found` | No client with the given `clientId` found, or no `DeviceManifest` registered for the given `deviceId` (capabilities endpoint only). |
+| `422 Unprocessable Content` | Request body includes a semantic error. |
+
+---
+
+### DeviceManifest
+
+Carries device identity only. Sent once at onboarding. Updated only if identity information changes.
+
+**Endpoint:** `POST /api/v1/clients/{clientId}/devices/{deviceId}`
+
+**Example:**
+
+```json
+{
+  "apiVersion": "margo.org/v1",
+  "kind": "DeviceManifest",
+  "properties": {
+    "id": "northstarida.xtapro.k8s.edge",
+    "vendor": "Northstar Industrial Devices",
+    "modelNumber": "332ANZE1-N1",
+    "serialNumber": "PF45343-AA"
+  }
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `apiVersion` | string | Y | Must be `margo.org/v1`. |
+| `kind` | string | Y | Must be `DeviceManifest`. |
+| `properties.id` | string | Y | Unique device identifier. Must include only unreserved characters as specified in RFC3986 plus the path separator `/`. |
+| `properties.vendor` | string | Y | Device vendor name. |
+| `properties.modelNumber` | string | Y | Device model number. |
+| `properties.serialNumber` | string | Y | Device serial number. |
+
+---
+
+### CapabilityState
+
+Each capability is submitted as an individual `CapabilityState` document. There is no wrapping manifest — the `CapabilityState` is the document.
+
+**Endpoint:** `POST /api/v1/clients/{clientId}/devices/{deviceId}/capabilities`
+
+The WFM uses `metadata.id` to identify which capability is being registered or updated. Submitting a `CapabilityState` for a `capability` URI that already exists for the device replaces the previous state.
+
+**Document structure:**
+
+```json
+{
+  "apiVersion": "margo.org/v1",
+  "kind": "CapabilityState",
+  "metadata": {
+    "id": "<capability-uri>"
+  },
+  "spec": {
+    // capability-specific state object
+  }
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `apiVersion` | string | Y | Must be `margo.org/v1`. |
+| `kind` | string | Y | Must be `CapabilityState`. |
+| `metadata.id` | string | Y | URI identifying the capability type. Determines the schema of `spec`. |
+| `spec` | object | Y | Runtime state for this capability. Content is governed by the schema for the referenced capability URI. |
+
+**DELETE — removing a capability:**
+
+To remove a capability from a device (e.g. hardware was physically removed), send a DELETE request with the capability URI in the request body:
+
+```
+DELETE /api/v1/clients/{clientId}/devices/{deviceId}/capabilities
+```
+
+```json
+{
+  "id": "capability.margo.org/hardware/gpu"
+}
+```
+
+The WFM MUST remove the stored `CapabilityState` for the given `capability` URI on the given device.
+
+---
+
+### Capability URI Namespace
+
+Capability URIs follow a reverse-DNS convention:
+
+| Namespace | Owner | Example |
+|-----------|-------|---------|
+| `capability.margo.org/*` | Margo specification — standardised capabilities | `capability.margo.org/hardware/gpu` |
+| `capability.<vendor-domain>/*` | Vendor-defined capabilities | `capability.acme.com/fieldbus/profinet` |
+
+The WFM MUST accept any well-formed URI in `metadata.id`. It MUST validate `spec` content against the schema for the referenced URI if a schema is registered. If no schema is registered for the URI, the WFM MUST store the `spec` as-is without validation.
+
+---
+
+### Standard Capability URIs Introduced by This SUP
+
+The following capability URIs replace the flat fields from the baseline schema. All are under the `capability.margo.org` namespace.
+
+#### `capability.margo.org/compute/cpu`
+
+Replaces the `cpu` array field.
+
+```json
+{
+  "apiVersion": "margo.org/v1",
+  "kind": "CapabilityState",
+  "metadata": {
+    "id": "capability.margo.org/compute/cpu"
+  },
+  "spec": {
+    "cpus": [
+      { "cores": 24, "architecture": "amd64" }
+    ]
+  }
+}
+```
+
+#### `capability.margo.org/compute/memory`
+
+Replaces the `memory` field.
+
+```json
+{
+  "apiVersion": "margo.org/v1",
+  "kind": "CapabilityState",
+  "metadata": {
+    "id": "capability.margo.org/compute/memory"
+  },
+  "spec": {
+    "available": "59 Gi"
+  }
+}
+```
+
+#### `capability.margo.org/compute/storage`
+
+Replaces the `storage` field.
+
+```json
+{
+  "apiVersion": "margo.org/v1",
+  "kind": "CapabilityState",
+  "metadata": {
+    "id": "capability.margo.org/compute/storage"
+  },
+  "spec": {
+    "available": "1862 Gi"
+  }
+}
+```
+
+#### `capability.margo.org/service/otel-collector`
+
+Replaces the `otelCollector` boolean field.
+
+```json
+{
+  "apiVersion": "margo.org/v1",
+  "kind": "CapabilityState",
+  "metadata": {
+    "id": "capability.margo.org/service/otel-collector"
+  },
+  "spec": {
+    "present": true
+  }
+}
+```
+
+#### `capability.margo.org/runtime/supported`
+
+Replaces the `supportedRuntimes` and `supportedDeploymentTypes` fields.
+
+```json
+{
+  "apiVersion": "margo.org/v1",
+  "kind": "CapabilityState",
+  "metadata": {
+    "id": "capability.margo.org/runtime/supported"
+  },
+  "spec": {
+    "runtimes": ["oci"],
+    "deploymentTypes": ["helm", "compose"]
+  }
+}
+```
+
+#### `capability.margo.org/hardware/gpu`
+
+Replaces `peripherals` entries of type `gpu`.
+
+```json
+{
+  "apiVersion": "margo.org/v1",
+  "kind": "CapabilityState",
+  "metadata": {
+    "id": "capability.margo.org/hardware/gpu"
+  },
+  "spec": {
+    "gpus": [
+      {
+        "devicePath": "/dev/nvidia0",
+        "model": "NVIDIA A100",
+        "architecture": "ampere",
+        "vramGiB": 40,
+        "allocatedTo": ""
+      }
+    ]
+  }
+}
+```
+
+#### `capability.margo.org/interface/ethernet`
+
+Replaces `interfaces` entries of type `ethernet` and `wifi`.
+
+```json
+{
+  "apiVersion": "margo.org/v1",
+  "kind": "CapabilityState",
+  "metadata": {
+    "id": "capability.margo.org/interface/ethernet"
+  },
+  "spec": {
+    "interfaces": [
+      { "name": "eth0", "speed": "1Gbps" },
+      { "name": "wlan0", "speed": "300Mbps" }
+    ]
+  }
+}
+```
+
+#### Vendor-defined example — `capability.acme.com/fieldbus/canbus`
+
+Vendor-defined capabilities follow the same structure. The WFM stores the `spec` as-is if no schema is registered for the URI.
+
+```json
+{
+  "apiVersion": "margo.org/v1",
+  "kind": "CapabilityState",
+  "metadata": {
+    "id": "capability.acme.com/fieldbus/canbus"
+  },
+  "spec": {
+    "channels": [
+      {
+        "channelId": "can0",
+        "baudRate": 500000,
+        "protocol": "CANopen",
+        "allocated": false,
+        "allocatedBy": ""
+      },
+      {
+        "channelId": "can1",
+        "baudRate": 250000,
+        "protocol": "J1939",
+        "allocated": true,
+        "allocatedBy": "deployment-sensor-monitor-003"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## What Changes, What Stays the Same
+
+| Field | Baseline (post roles-SUP) | After This SUP |
+|-------|--------------------------|----------------|
+| `id`, `vendor`, `modelNumber`, `serialNumber` | In `DeviceCapabilitiesManifest` | Moved to `DeviceManifest` — separate endpoint |
+| `cpu` | Flat array in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/compute/cpu` |
+| `memory` | Flat field in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/compute/memory` |
+| `storage` | Flat field in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/compute/storage` |
+| `otelCollector` | Flat boolean in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/service/otel-collector` |
+| `supportedRuntimes` | Flat array in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/runtime/supported` |
+| `supportedDeploymentTypes` | Flat array in `DeviceCapabilitiesManifest` | `CapabilityState` — `capability.margo.org/runtime/supported` |
+| `peripherals` | Flat enum | Removed — expressed as `CapabilityState` per hardware type |
+| `interfaces` | Flat enum | Removed — expressed as `CapabilityState` per interface type |
+| Gateway hierarchy encoding | In endpoint path | Unchanged — retained on both new endpoint groups |
+| Onboarding order | Single document | `DeviceManifest` MUST precede first `CapabilityState` |
+| Update granularity | Entire document re-sent | One `CapabilityState` per capability, updated independently |
+
+---
+
+## Alternatives Considered
+
+**Keep a single endpoint, split the schema into two sub-objects.** Rejected. Separate endpoints make the lifecycle difference explicit — the WFM can apply different caching, validation, and update logic to identity vs capability data without inferring it from the payload structure.
+
+**Keep `peripherals` and `interfaces` as deprecated fields alongside `capabilities[]`.** Rejected. Keeping deprecated fields creates ambiguity about which is authoritative when both are present. A clean removal forces implementations to adopt the structured model immediately and avoids a dual-path validation burden on the WFM.
+
+**Wrap all capabilities in a `DeviceCapabilitiesManifest` array.** Rejected. A wrapping manifest requires re-sending all capabilities to update one. Individual `CapabilityState` documents allow the device to update a single capability (e.g. GPU allocation state changed) without touching others.
+
+**Encode the capability URI in the endpoint path.** Rejected. The `CapabilityState` document already carries the URI in `metadata.id`. Duplicating it in the path adds no information and introduces encoding complexity for URIs containing slashes.
+
+---
+
+## Open Questions
+
+1. Gateway capability reporting — opaque and see-thru gateway `CapabilityState` update semantics following Gateway SUP injection. To be addressed in a follow-on proposal.

--- a/proposals/sup_bisect_device_manifest.md
+++ b/proposals/sup_bisect_device_manifest.md
@@ -129,7 +129,7 @@ A `ProfileDefinition` is authored once — by Margo Community, a device vendor, 
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `profileDefinitionId` | string | Y | URI uniquely identifying this profile type. |
+| `profileDefinitionId` | string | Y | URI uniquely identifying this profile type. It must be a lower-case Reverse DNS string (e.g., deviceprofile.margo.org/peripherals/gpu). |
 | `scope` | enum | Y | `device` — owned and published by Device Agent, `fleet` - owned by WFM(not introduced in this SUP) |
 | `category` | enum | Y | One of `resource`, `interface`, `peripheral`, `service`, `capability`. Formally declares which category this profile belongs to. |
 | `schemaVersion` | string | Y | Semantic version of this `ProfileDefinition` schema (e.g. `1.0.0`). Used to detect schema evolution and trigger re-validation of existing `ProfileState` documents. |
@@ -177,24 +177,16 @@ A `ProfileState` is submitted by the profile owner after device onboarding and u
 
 ## Introducing Device Profile
 
-A Device Profile is a complete list of everything a device has to offer. It describes all the hardware resources, communication tools, extra plug-in parts, and built-in software services available on that machine.
+A Device Profile is a complete list of Profiles it has to offer. It describes all the hardware resources, communication tools, extra plug-in parts, and built-in software services available on that machine.
 
 A Device Profile groups these features into five categories:
 * **Resources:** Countable hardware parts like CPU cores, system memory (RAM), and disk drive storage space.
 * **Interfaces:** Parts that connect the device to networks or other hardware, such as Ethernet ports, Wi-Fi chips, CAN Bus links, and USB ports.
 * **Peripherals:** Extra physical hardware parts built into or attached to the device, like graphics cards (GPUs), cameras, or microphones.
-* **Services:** Built-in software features run by the device itself, such as a secure password vault, a local DNS server, or an OpenTelemetry (OTel) log collector.
+* **Services:** Built-in software features run by the device itself, such as a secure password vault, a local DNS server, a centralized message queue, or an OpenTelemetry (OTel) server.
 * **Capabilities:** The actual actions the device can do (like processing AI models, encoding video files, or gathering system metrics) because it has the right mix of hardware and services.
 
-## Important Difference: Things vs. Capabilities
-
-To keep your configuration clear, do not confuse a physical thing with what that thing can do (its capability). Things are pieces of hardware or software services that work together to make a capability possible.
-
-* A GPU (a thing) is not a capability. It is a part that makes AI acceleration and video encoding (capabilities) possible.
-* A Secret Vault (a thing) is not a capability. It is a service that makes secure password saving (a capability) possible.
-* An Ethernet Interface (a thing) is not a capability. It is a port that makes network communication (a capability) possible.
-
-A `ProfileDefinition` with `category: capability` MUST describe an action or outcome the device can perform — not a hardware part or software service. The WFM SHOULD warn if a capability `ProfileDefinition` is submitted whose `profileDefinitionId` path segment matches a known hardware or service type name.
+NOTE: We can add more or change them based on the consensus amongst the community.
 
 ## Room to Grow (Future Profiles)
 
@@ -247,7 +239,7 @@ Each POST or PUT to the profile endpoint carries an array of `ProfileState` docu
 ]
 ```
 
-The WFM processes all items atomically: either all succeed or all fail. When a batch fails, the WFM MUST return a `422 Unprocessable Content` response identifying which `profileDefinitionId` caused the failure:
+The WFM processes all items atomically: either all succeed or all fail. When it fails, the WFM MUST return a `422 Unprocessable Content` response identifying which `profileDefinitionId` caused the failure:
 
 ```json
 {

--- a/proposals/sup_bisect_device_manifest.md
+++ b/proposals/sup_bisect_device_manifest.md
@@ -96,7 +96,7 @@ A `ProfileDefinition` is authored once — by Margo Community, a device vendor, 
 ```json
 {
   "profileDefinitionId": "deviceprofile.margo.org/peripherals/gpu",
-  "description": "Profile Definition for GPU peripherals",
+  "description": "Profile Definition for GPU peripheral hardware",
   "scope": "device",
   "category": "peripheral",
   "schemaVersion": "1.0.0",
@@ -111,10 +111,16 @@ A `ProfileDefinition` is authored once — by Margo Community, a device vendor, 
           "type": "object",
           "required": ["model", "manufacturer"],
           "properties": {
-            "manufacturer": { "type": "string" },
-            "model": { "type": "string" },
-            "vram": { "type": "string" },
-            "architecture": { "type": "string" }
+            "manufacturer": { "type": "string", "description": "GPU manufacturer name" },
+            "model": { "type": "string", "description": "GPU model name" },
+            "vram": {
+              "type": "object",
+              "description": "Video RAM capacity",
+              "properties": {
+                "unit": { "type": "string", "enum": ["bytes", "Ki", "Mi", "Gi"] },
+                "value": { "type": "integer", "minimum": 1 }
+            },
+            "architecture": { "type": "string", "description": "GPU compute architecture (e.g. Ampere)" }
           }
         }
       }
@@ -158,7 +164,7 @@ A `ProfileState` is submitted by the profile owner after device onboarding and u
       {
         "manufacturer": "NVIDIA",
         "model": "A100",
-        "vram": "80Gi",
+        "vram": { "unit": "Gi", "value": 10 },
         "architecture": "Ampere"
       }
     ]
@@ -490,22 +496,16 @@ Carries device identity only. Sent once at onboarding. Updated only if identity 
         "minItems": 1,
         "items": {
           "type": "object",
-          "required": ["manufacturer"],
+          "required": ["model", "manufacturer"],
           "properties": {
             "manufacturer": { "type": "string", "description": "GPU manufacturer name" },
             "model": { "type": "string", "description": "GPU model name" },
-            "vram": { 
-              "unit": {
-                "type": "string",
-                "enum": ["bytes", "Ki", "Mi", "Gi"],
-                "description": "Binary unit for memory measurement"
-              },
-              "value": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "Total memory value in the specified unit"
-              },
-              "description": "Video RAM capacity (e.g. 80Gi)"
+            "vram": {
+              "type": "object",
+              "description": "Video RAM capacity",
+              "properties": {
+                "unit": { "type": "string", "enum": ["bytes", "Ki", "Mi", "Gi"] },
+                "value": { "type": "integer", "minimum": 1 }
             },
             "architecture": { "type": "string", "description": "GPU compute architecture (e.g. Ampere)" }
           }


### PR DESCRIPTION
This Specification Update Proposal (SUP) addresses the data coupling and scalability issues identified in [issue](https://github.com/margo/specification/issues/191).

It refactors the DeviceCapabilitiesManifest schema to decouple static device identification from dynamic hardware and runtime capability states, establishing a clean baseline for future capability frameworks.